### PR TITLE
corrects the fact that the pointer to Coq workshop get 'page not found'

### DIFF
--- a/pages/1.html
+++ b/pages/1.html
@@ -75,7 +75,7 @@ extensions of Coq, and tools based on Coq (see <a href="/related-tools">Related 
 
 <div class="frameworklinks">
 <ul>
-<li><a href="/coq-workshop/">The Coq workshop</a></li>
+<li><a href="/coq-workshop">The Coq workshop</a></li>
 <li><a href="/contribs">Users' Contributions</a></li>
 <li><a href="/related-tools">Related Tools</a></li>
 <li><a href="/community">Contacts</a></li>


### PR DESCRIPTION
This modification has been tested using the "make run" option described in README