### PR TITLE
OPAM as a package manager from OCamlPro

### DIFF
--- a/pages/31.html
+++ b/pages/31.html
@@ -4,10 +4,10 @@
 <div class="framework">
   <div class="frameworklabel">Use OPAM</div>
   <div class="frameworkcontent">
-    <p>OPAM is a package manager for OCaml, which can be used to install
-      Coq and many of its packages.  The general documentation can be
-      found on the
-      <a href="http://opam.ocaml.org/">OPAM website</a>.
+    <p><a href="http://opam.ocamlpro.com/">OPAM</a> is a package manager edited
+      by <a href="http://www.ocamlpro.com/">OCamlPro</a>, which can be used to
+      install Coq and many of its packages. You can find the general
+      documentation <a href="http://opam.ocaml.org/doc/">here</a>.
 
       For example, to install the version <code>1.2.2</code> of OPAM
       from the sources on a Unix system:</p>


### PR DESCRIPTION
To be even more precise, OPAM is a package manager made by OCamlPro, originally for OCaml but not only (see the [official page](http://opam.ocamlpro.com/)). For now they support OCaml and Xen, and hopefully they will be able to officially talk about Coq soon.