### PR TITLE
Updated OPAM instructions

### DIFF
--- a/pages/31.html
+++ b/pages/31.html
@@ -30,7 +30,6 @@ sudo make install</pre>
     <pre>opam repo add coq-extra-dev https://coq.inria.fr/opam/extra-dev</pre>
     <p>To add the repository of development versions of Coq (use it at your own risks):</p>
     <pre>opam repo add coq-core-dev https://coq.inria.fr/opam/core-dev</pre>
-    <p>TODO: talk about the distribution mechanism.</p>
   </div>
 </div>
 

--- a/pages/31.html
+++ b/pages/31.html
@@ -25,7 +25,7 @@ sudo make install</pre>
     <p>To install the version <code>8.4.6</code> of Coq:</p>
     <pre>opam pin add coq 8.4.6</pre>
     <p>To install a package:</p>
-    <pre>opam install coq:that-super-package</pre>
+    <pre>opam install coq-that-super-package</pre>
     <p>To add the repository of development packages (use it at your own risks):</p>
     <pre>opam repo add coq-extra-dev https://coq.inria.fr/opam/extra-dev</pre>
     <p>To add the repository of development versions of Coq (use it at your own risks):</p>

--- a/pages/31.html
+++ b/pages/31.html
@@ -25,11 +25,12 @@ sudo make install</pre>
     <p>To install the version <code>8.4.6</code> of Coq:</p>
     <pre>opam pin add coq 8.4.6</pre>
     <p>To install a package:</p>
-    <pre>opam install coq-that-super-package</pre>
-    <p>To add the repository of development packages (use it at your own risks):</p>
-    <pre>opam repo add coq-extra-dev https://coq.inria.fr/opam/extra-dev</pre>
-    <p>To add the repository of development versions of Coq (use it at your own risks):</p>
-    <pre>opam repo add coq-core-dev https://coq.inria.fr/opam/core-dev</pre>
+    <pre>opam install coq-compcert</pre>
+    <p>To list all the Coq packages:</p>
+    <pre>opam search coq</pre>
+    <p>To install the beta version of Coq:</p>
+    <pre>opam repo add coq-core-dev https://coq.inria.fr/opam/core-dev
+opam pin add coq 8.5~beta3</pre>
   </div>
 </div>
 

--- a/pages/31.html
+++ b/pages/31.html
@@ -20,8 +20,10 @@ make
 sudo make install</pre>
     <p>To add the repository for the Coq packages:</p>
     <pre>opam repo add coq-released https://coq.inria.fr/opam/released</pre>
-    <p>To install Coq:</p>
-    <pre>opam install -j4 -v coq</pre>
+    <p>To list all the version of Coq:</p>
+    <pre>opam show --field=available-versions coq</pre>
+    <p>To install the version <code>8.4.6</code> of Coq:</p>
+    <pre>opam pin add coq 8.4.6</pre>
     <p>To install a package:</p>
     <pre>opam install coq:that-super-package</pre>
     <p>To add the repository of development packages (use it at your own risks):</p>


### PR DESCRIPTION
These new instructions take into account:
* the replacement of `:` by `-`;
* the recommendation to pin the version of Coq;
* the case of Coq beta.
