### PR TITLE
Add web page for the Coq Workshop 2016

### DIFF
--- a/PAGES
+++ b/PAGES
@@ -74,3 +74,4 @@
 125:coq-workshop/2015/cfp
 130:coq-itp-2015
 131:coq-workshop/2016
+131:the-coq-workshop-2016

--- a/PAGES
+++ b/PAGES
@@ -73,3 +73,4 @@
 124:the-coq-workshop-2015
 125:coq-workshop/2015/cfp
 130:coq-itp-2015
+131:coq-workshop/2016

--- a/pages/131.html
+++ b/pages/131.html
@@ -1,0 +1,49 @@
+<#def TITLE>The Coq Workshop 2016</#def>
+<#include "incl/header.html">
+
+<p>The 8th Coq Workshop</p>
+<p><em><br />
+Nancy, France<br />
+August 26, 2016<br />
+(A satellite workshop of <a href="https://itp2016.inria.fr/">ITP 2016</a>)<br />
+</em></p>
+<p><a href="/coq-workshop">The Coq Workshop</a> series brings together Coq users, developers, and contributors.  While conferences like ITP provide a venue for traditional research papers, the Coq Workshop focuses on strengthening the Coq community and providing a forum for discussing practical issues, including the future of the Coq software and its associated ecosystem of libraries and tools.  Thus, the workshop will be organized around informal presentations and discussions, supplemented with invited talks.</p>
+
+<p>Submission Instructions</p>
+<p>We invite all members of the Coq community to propose informal talks, discussion sessions, or any potential uses of the day allocated to the workshop.  Relevant subject matter includes but is not limited to:</p>
+<ul>
+  <li>Language or tactic features</li>
+  <li>Theory and implementation of the Calculus of Inductive Constructions</li>
+  <li>Applications and experience in education and industry</li>
+  <li>Tools and platforms built on Coq</li>
+  <li>Plugins and libraries for Coq</li>
+  <li>Interfacing with Coq</li>
+  <li>Formalization tricks and Coq pearls</li>
+</ul>
+<p>Authors should submit short proposals through <a href="https://www.easychair.org/conferences/?conf=coq8">EasyChair</a>.  Submissions should be in portable document format (PDF).  Proposals should not exceed 2 pages in length in single-column full-page style.</p>
+<p>This year, we are open to many ideas on how to use the workshop time.  Some suggestions to drive proposals include sessions on tool demonstrations or lessons learned from teaching Coq.</p>
+<p>Important Dates</p>
+<ul>
+<li>June 15: Deadline for proposal submission</li>
+<li>June 30: Acceptance notification</li>
+<li>August 26: Workshop in Nancy</li>
+</ul>
+<p>Submission URL</p>
+<p><a href="https://www.easychair.org/conferences/?conf=coq8">https://www.easychair.org/conferences/?conf=coq8</a> </p>
+<p>Program Committee (to be completed) </p>
+<ul>
+  <li><a href="http://dpt-info.u-strasbg.fr/~magaud/">Nicolas Magaud</a> (Organizer), University of Strasbourg</li>
+  <li><a href="http://dpt-info.u-strasbg.fr/~narboux/">Julien Narboux</a> (Organizer), University of Strasbourg</li>
+  <!-- <li><a href="http://www-sop.inria.fr/members/Yves.Bertot/">Yves Bertot</a>, INRIA, France</li> -->
+  <!-- <li><a href="http://www.chargueraud.org/">Arthur Charguéraud</a>, MPI-SWS, Germany</li> -->
+  <!-- <li><a href="http://adam.chlipala.net/">Adam Chlipala</a> (chair), MIT, USA</li> -->
+  <!-- <li><a href="http://www.mpi-sws.org/~gil/">Chung-Kil Hur</a>, MPI-SWS, Germany</li> -->
+  <!-- <li><a href="http://www.lix.polytechnique.fr/~assia/">Assia Mahboubi</a>, INRIA, France</li> -->
+  <!-- <li><a href="http://www.cs.yale.edu/~shao-zhong/">Zhong Shao</a>, Yale, USA</li> -->
+  <!-- <li><a href="http://www.cs.ru.nl/~spitters/">Bas Spitters</a>, Nijmegen, Netherlands</li> -->
+  <!-- <li><a href="http://labs.oracle.com/people/tristan">Jean-Baptiste Tristan</a>, Oracle, USA</li> -->
+  <!-- <li><a href="http://www.math.ias.edu/~vladimir/Site3/home.html">Vladimir Voevodsky</a>, IAS, USA</li> -->
+</ul>
+<p><em>The workshop is supported by the Coq Technological Development Action (at INRIA).</em></p>
+
+<#include "incl/footer.html">

--- a/pages/131.html
+++ b/pages/131.html
@@ -32,8 +32,8 @@ August 26, 2016<br />
 <p><a href="https://www.easychair.org/conferences/?conf=coq8">https://www.easychair.org/conferences/?conf=coq8</a> </p>
 <p>Program Committee (to be completed) </p>
 <ul>
-  <li><a href="http://dpt-info.u-strasbg.fr/~magaud/">Nicolas Magaud</a> (Organizer), University of Strasbourg</li>
-  <li><a href="http://dpt-info.u-strasbg.fr/~narboux/">Julien Narboux</a> (Organizer), University of Strasbourg</li>
+  <!-- <li><a href="http://dpt-info.u-strasbg.fr/~magaud/">Nicolas Magaud</a> (Organizer), University of Strasbourg</li> -->
+  <!-- <li><a href="http://dpt-info.u-strasbg.fr/~narboux/">Julien Narboux</a> (Organizer), University of Strasbourg</li> -->
   <!-- <li><a href="http://www-sop.inria.fr/members/Yves.Bertot/">Yves Bertot</a>, INRIA, France</li> -->
   <!-- <li><a href="http://www.chargueraud.org/">Arthur Charguéraud</a>, MPI-SWS, Germany</li> -->
   <!-- <li><a href="http://adam.chlipala.net/">Adam Chlipala</a> (chair), MIT, USA</li> -->
@@ -44,6 +44,11 @@ August 26, 2016<br />
   <!-- <li><a href="http://labs.oracle.com/people/tristan">Jean-Baptiste Tristan</a>, Oracle, USA</li> -->
   <!-- <li><a href="http://www.math.ias.edu/~vladimir/Site3/home.html">Vladimir Voevodsky</a>, IAS, USA</li> -->
 </ul>
-<p><em>The workshop is supported by the Coq Technological Development Action (at INRIA).</em></p>
+
+<h2>Organization</h2>
+
+<strong>Contacts:</strong> <t>magaud@unistra.fr</t> and <t>narboux@unistra.fr</t>
+
+<!-- <p><em>The workshop is supported by INRIA.</em></p> -->
 
 <#include "incl/footer.html">

--- a/pages/88.html
+++ b/pages/88.html
@@ -3,6 +3,7 @@
 
 <p>The Coq Workshop brings together Coq users, developers and contributors.  It usually consists of one-day events affiliated with larger conferences.  This series of events was started in 2009 and now contains the following workshops:</p>
 <ul>
+<li><a href="/coq-workshop/2016">2016, August 26th, Nancy, France</a></li>
 <li><a href="/coq-workshop/2015">2015, June 26th, Sophia Antipolis, France</a></li>
 <li><a href="http://coqpl.cs.washington.edu">2015, January 18th, Mumbai, India (CoqPL, affiliated to POPL)</a></li>
 <li><a href="http://www.easychair.org/smart-program/VSL2014/Coq-index.html">2014, July 18th, Vienna, Austria</a></li>


### PR DESCRIPTION
As organizer for Coq Workshop 2016 I would like to add the webpage on Coq's site as for previous years.

