### PR TITLE
Adding OPAM repository names for Coq, targetting experienced OPAM users.

### DIFF
--- a/pages/104.html
+++ b/pages/104.html
@@ -114,6 +114,9 @@ CHANGES</a>.</p>
 
 </table>
 
+Experienced <a href="https://opam.ocamlpro.com">OPAM</a> users can find
+Coq 8.4pl6 and CoqIDE 8.4pl6 on the <a href="https://opam.ocaml.org">main</a> OPAM repository.
+
 </div>
 </div>
 

--- a/pages/110.html
+++ b/pages/110.html
@@ -130,6 +130,9 @@ CHANGES</a>.</p>
 
 </table>
 
+Experienced <a href="https://opam.ocamlpro.com">OPAM</a> users can
+find Coq 8.5rc1 in the <tt>https://coq.inria.fr/opam/core-dev</tt> repository.
+
 </div><!-- frameworkcontent -->
 </div><!-- framework -->
 


### PR DESCRIPTION
Proposal to inform experienced OPAM users of the repository name for installing Coq via OPAM.

This is an alternative to https://github.com/coq/www/pull/18 which had problems with layout and did not get a consensus on recommending a "pin".
