### PR TITLE
For python3, bind testing server only to localhost

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,4 +127,4 @@ printenv:
 run: aliases
 	@echo "Starting a local web server for test"
 	@echo "It is accessible at: http://localhost:8000"
-	cd $(DST) && (python -m http.server 8000 || python -m SimpleHTTPServer 8000)
+	cd $(DST) && (python3 -m http.server --bind localhost 8000 || python -m SimpleHTTPServer 8000)


### PR DESCRIPTION
By default, http.server binds to all interfaces (0.0.0.0). Unfortunately
there is no way to select the address to bind to for the
SimpleHTTPServer module from the command line in Python 2.7.

This is both safer (the testing server isn't potentially accessible to the
outside world) and avoids a security warning in OS X due to Python requesting
access to incoming network connections.
