### PR TITLE
community and contribution-index pages switched to OPAM

### DIFF
--- a/pages/community.html
+++ b/pages/community.html
@@ -6,17 +6,31 @@
 
 <div class="frameworkcontent">
 
-<p>As a generic proof assistant, Coq can be used in various ways either to write formal specifications of system and software, or as a basis tool for software verification. You can refer to our repository of <a href="/contribs/">users' contributions</a> to get an overview of existing formalizations written in Coq. You can also visit the page dedicated to <a href="related-tools">related tools</a> to see a list of extensions and tools based on Coq.</p>
+<p>
+The Coq community has contributed a large ecosystem of formalization works and plugins throughout the years.
+An index of OPAM packages can be <a href="/opam/www/archive.html">browsed online</a>.
+Users are encouraged to <a href="/packages">submit their packages to the index</a>.
+</p>
 
-<p>You can interact with other users of Coq through the <a class="extlink" href="https://sympa.inria.fr/sympa/info/coq-club">Coq-club mailing list</a>; the <a href="https://sympa.inria.fr/sympa/arc/coq-club">list archives</a> are also a good source of information.
-There is also a wiki dedicated to Coq: <a class="extlink" href="/cocorico/">Cocorico!</a>, where you can share your experience with other users.</p>
+<p>
+The Coq community has also built tools around the Coq system.
+You can also visit the page dedicated to <a href="related-tools">related tools</a>.
+</p>
 
-<p>Coq does not necessarily have to be used with the standard sets of tactics and standard library coming bundled with the system. Some users might want to use their own specialized tactics and/or libraries. Examples include the <a class="extlink" href="http://www.msr-inria.inria.fr/projects/mathematical-components-2/">Ssreflect project</a>, the <a class="extlink" href="http://ynot.cs.harvard.edu/">Y-not project</a>, <a class="extlink" href="http://www.cis.upenn.edu/~bcpierce/sf/">Software Foundations</a>, <a class="extlink" href="http://ltamer.sourceforge.net/">Lambda Tamer</a>, <a class="extlink" href="http://www.chargueraud.org/">Charguéraud's tactics</a>, <a class="extlink" href="http://compcert.inria.fr/doc/index.html">CompCert</a>, ...
-</p></div>
+<p>
+You can interact with other users of Coq through the 
+<a class="extlink" href="https://sympa.inria.fr/sympa/info/coq-club">Coq-club mailing list</a>;
+the <a href="https://sympa.inria.fr/sympa/arc/coq-club">list archives</a> are 
+also a good source of information.  There is also a wiki dedicated to Coq:
+<a class="extlink" href="/cocorico/">Cocorico!</a>, where you can share 
+your experience with other users.
+</p>
+
+</div>
 
 <div class="frameworklinks">
 <ul>
-<li><a href="/contribs/">Users' contributions</a></li>
+<li><a href="/packages">Coq Package Index</a></li>
 <li><a href="/related-tools">Related Tools</a></li>
 <li><a href="https://sympa.inria.fr/sympa/arc/coq-club">Coq-club</a></li>
 <li><a class="extlink" href="/cocorico/">Cocorico!</a></li>
@@ -26,20 +40,27 @@ There is also a wiki dedicated to Coq: <a class="extlink" href="/cocorico/">Coco
 
 <div class="framework">
   <div class="frameworklabel">The Coq development team</div>
-<div class="frameworkcontent"><p>You can contact directly the Coq
-    developpers through
-    the <a class="extlink" href="mailto:coqdev-NOSPAM@inria.fr">Coq-dev mailing list</a>
-    (subscribe <a class="extlink" href="https://sympa.inria.fr/sympa/info/coqdev">here</a>). If you want to report a bug, please consider using
-    our <a class="extlink" href="/bugs/">bug tracking system</a>.
+<div class="frameworkcontent">
+	
+<p>
+You can contact directly the Coq developers through the
+<a class="extlink" href="https://sympa.inria.fr/sympa/info/coqdev">coqdev mailing list</a>.
+If you want to report a bug, please consider using
+our <a class="extlink" href="/bugs/">bug tracking system</a>.
+</p>
 
-  The Coq developers and interested users gather for <a class="extlink" href="/WGs">working groups</a> a few times a year.
+<p>
+The Coq developers and interested users gather for
+<a class="extlink" href="https://coq.inria.fr/cocorico/CoqDevelopment/">working groups</a>
+a few times a year.  You are welcome to attend!
 </p>
 </div>
 
 <div class="frameworklinks">
 <ul>
-<li><a href="mailto:coqdev-NOSPAM@inria.fr">Mail to Coq-dev</a></li>
-<li><a class="extlink" href="/bugs/">Coq-bugs</a></li>
+<li><a href="https://sympa.inria.fr/sympa/info/coqdev">coqdev</a></li>
+<li><a class="extlink" href="/bugs/">bug tracker</a></li>
+<li><a class="extlink" href="https://coq.inria.fr/cocorico/CoqDevelopment/">working groups</a></li>
 </ul>
 </div>
 </div><!-- /framework -->

--- a/pages/faq.html
+++ b/pages/faq.html
@@ -718,8 +718,8 @@ development of zero-default software.&#8221;
 There are examples in the manual&nbsp;[<a href="#Coq:manual"><cite>17</cite></a>] and in the
 Coq'Art&nbsp;[<a href="#Coq:coqart"><cite>2</cite></a>] exercises <a href="http://www.labri.fr/perso/casteran/CoqArt/"><tt> http://www.labri.fr/perso/casteran/CoqArt/</tt> </a>.
 You can also find large developments using
-<span class="caps">Coq</span> in the <span class="caps">Coq</span> user contributions:
-<a href="/contribs"><tt> http://coq.inria.fr/contribs</tt> </a>.<br/>
+<span class="caps">Coq</span> in the <span class="caps">Coq</span> Package Index:
+<a href="/packages"><tt> http://coq.inria.fr/packages</tt> </a>.<br/>
 <br/>
 <!--TOC subsubsection How can I report a bug?-->
 

--- a/pages/index.html
+++ b/pages/index.html
@@ -65,9 +65,11 @@
 <div class="frameworkcontent">
   
 <p>There is a strong and active community of users working with
-Coq. They are contributing formal developments (see <a
-href="/contribs">Coq Users' Contributions</a>),
-extensions of Coq, and tools based on Coq (see <a href="/related-tools">Related Tools</a>).
+Coq. They are contributing formal developments,
+extensions of Coq
+(see <a href="/packages">Coq Package Index</a>)
+, and tools based on Coq
+(see <a href="/related-tools">Related Tools</a>).
 </p>
 
 </div>
@@ -75,9 +77,9 @@ extensions of Coq, and tools based on Coq (see <a href="/related-tools">Related 
 <div class="frameworklinks">
 <ul>
 <li><a href="/coq-workshop">The Coq workshop</a></li>
-<li><a href="/contribs">Users' Contributions</a></li>
+<li><a href="/packages">Coq Package Index</a></li>
 <li><a href="/related-tools">Related Tools</a></li>
-<li><a href="/community">Contacts</a></li>
+<li><a href="/community">Community</a></li>
 </ul>
 </div>
 </div><!-- /framework -->

--- a/pages/packages.html
+++ b/pages/packages.html
@@ -16,6 +16,15 @@ can be <a href="/opam/www/archive.html">browsed online</a>.
 </p>
 
 <p>
+We provide instructions on 
+<a href="/opam/www/using.html">
+how to install Coq and related packages via OPAM
+</a>
+step by step.
+</p>
+
+
+<p>
 You are encouraged to make your Coq developments visible and easily installable
 by <a href="/opam/www/packaging.html">submitting them to the Coq Package Index</a>.
 </p>

--- a/pages/packages.html
+++ b/pages/packages.html
@@ -1,0 +1,32 @@
+<#def TITLE>Coq Package Index</#def>
+<#include "incl/header.html">
+
+<div class="framework">
+<div class="frameworklabel">Index of Coq Packages</div>
+<div class="frameworkcontent">
+
+<p>
+Coq developments (formalizations, plugins) can be packaged using 
+<a href="http://opam.ocaml.org">OPAM</a>.
+OPAM makes it easy to install a package by taking care of the compilation
+process and resolving all package dependencies.
+
+The Coq development team maintains an index of such packages that
+can be <a href="/opam/www/archive.html">browsed online</a>.
+</p>
+
+<p>
+You are encouraged to make your Coq developments visible and easily installable
+by <a href="/opam/www/packaging.html">submitting them to the Coq Package Index</a>.
+</p>
+
+</div>
+<div class="frameworklinks">
+<ul>
+<li><a href="/opam/www/archive.html">Browse the index</a></li>
+<li><a href="/opam/www/packaging.html">Submit a new package</a></li>
+</ul>
+</div>
+</div>
+
+<#include "incl/footer.html">

--- a/styles/barron/style.css
+++ b/styles/barron/style.css
@@ -513,17 +513,21 @@ td.active {
 }
 
 /* Additional Styles */
-/* Pierre L: off to mimic the old style (cf coq-83 page)
-code, pre {
-  background:#FFF9F9;
-  border:1px dashed #FF6868;
-  display:block;
-  overflow:auto;
-  padding:10px;
+pre {
+  background-color: rgb(245, 245, 245);
+  border-color: rgb(204, 204, 204);
+  border-radius: 4px;
+  border-style: solid;
+  border-width: 1px;
+  padding:12px;
   margin:10px;
-  white-space: pre;
 }
-*/
+code {
+  background-color: rgb(245, 245, 245);
+  font-family:monospace;
+  padding: 2px;
+  border-radius: 4px;
+}
 
 #footer #credits {
   float: right;


### PR DESCRIPTION
@mattam82 please check the new text I wrote with @maximedenes 

The second commit is relevant for the PR on coq-opam-archive where the instruction on how to install a package or write a package use code blocks (the css is shared among the 2 sites)