### PR TITLE
use /coq-85 link instead of /download for 8.5pl2 and 8.5pl3

### DIFF
--- a/news/130
+++ b/news/130
@@ -3,7 +3,7 @@
 <#def AUTHOR>Maxime Dénès</#def>
 <#def DATE>11 Jul 2016</#def>
 <#def DESCR>
-<a href="/download">Version 8.5pl2 of Coq</a> is available. It fixes several bugs
+<a href="/coq-85">Version 8.5pl2 of Coq</a> is available. It fixes several bugs
 of version 8.5pl1, including one critical bug. More information can be found in
 the <a href="/distrib/V8.5pl2/CHANGES">CHANGES</a> file. Feedback and
 <a href="/bugs">bug reports</a> are extremely welcome.

--- a/news/131
+++ b/news/131
@@ -3,7 +3,7 @@
 <#def AUTHOR>Maxime Dénès</#def>
 <#def DATE>27 Oct 2016</#def>
 <#def DESCR>
-<a href="/download">Version 8.5pl3 of Coq</a> is available. It fixes several bugs
+<a href="/coq-85">Version 8.5pl3 of Coq</a> is available. It fixes several bugs
 of version 8.5pl2, including one critical bug. More information can be found in
 the <a href="/distrib/V8.5pl3/CHANGES">CHANGES</a> file. Feedback and
 <a href="/bugs">bug reports</a> are extremely welcome.


### PR DESCRIPTION
The download links for 8.5pl2 and pl3 used the default download location, which I reported in Bugzilla as 5409. I've substituted the coq-85 download link.