### PR TITLE
add All Downloads link to footer

### DIFF
--- a/incl/footer.html
+++ b/incl/footer.html
@@ -8,6 +8,16 @@ Still opened: html body div.container div#content div.node div.content
 </div><!-- /content -->
 <div id="sidebar-wrapper">
   <div id="sidebar">
+    <div id="block-block-1" class="clear-block block block-block">
+      <h2 class="title">All downloads</h2>
+      <div class="content">
+        <div class="item-list">
+	  <ul>
+            <li><a href="https://coq.inria.fr/distrib/">Coq download site</a></li>
+          </ul>
+        </div>
+      </div>
+    </div>
     <div id="block-aggregator-feed-1" class="clear-block block block-aggregator">
       <h2 class="title">Recent news</h2>
       <div class="content">


### PR DESCRIPTION
This adds a link to the directory of all downloads to the footer. Maybe that's not the right place for the link, since the footer appears in many places; if it's an OK place, maybe the link should be after the "News" items.

Also, maybe there's a better URL than that, is there another download site? There looks to be some stuff in that directory that could be cleaned up, like the "nightly"and "trunk" directories that appear to be unused.