### PR TITLE
Link to previous versions

### DIFF
--- a/pages/download.html
+++ b/pages/download.html
@@ -169,4 +169,19 @@ and a discussion period on new features.</p>
 </div><!-- frameworkcontent -->
 </div><!-- framework -->
 
+<div class="framework">
+<div class="frameworklabel">Previous and development versions of Coq </div>
+<div class="frameworkcontent">
+
+  <p> The previous stable release of the Coq system is <a
+  href="/coq-85">version 8.5</a>.</p>
+
+   <p>The development version of Coq is <a href="https://gforge.inria.fr/scm/browser.php?group_id=269">browsable</a> and downloadable from our Git repository using command:
+	  <tt>git clone git://scm.gforge.inria.fr/coq/coq.git</tt>. The daily level of stability of this version can be observed at the <a href="https://ci.inria.fr/coq/job/bench-clone-coq/">bench-clone-coq</a> site.
+   </p>
+   <p>Most of the previous versions of Coq are available <a href="/distrib/">here</a>.</p>
+
+</div>
+</div>
+
 <#include "incl/footer.html">


### PR DESCRIPTION
While looking at the v8.5 packages, I realized that there were no link even to the "distrib" directory. This commit adds a minimal content to find previous package. Incidentally, it also gives a link to (one) of the bench directories. This is a bit arbitrary but probably not useless.