### PR TITLE
add Github link to Community page

### DIFF
--- a/pages/community.html
+++ b/pages/community.html
@@ -50,6 +50,11 @@ our <a class="extlink" href="/bugs/">bug tracking system</a>.
 </p>
 
 <p>
+You can follow the Coq development process at the Coq <a href="https://github.com/coq/coq/">GitHub repository</a>.
+The Coq team welcomes your suggestions and improvements submitted via GitHub pull requests.
+</p>
+
+<p>
 The Coq developers and interested users gather for
 <a class="extlink" href="https://coq.inria.fr/cocorico/CoqDevelopment/">working groups</a>
 a few times a year.  You are welcome to attend!


### PR DESCRIPTION
Such a link was requested in https://coq.inria.fr/bugs/show_bug.cgi?id=4570.