### PR TITLE
Capitalize some words for uniformity

### DIFF
--- a/pages/community.html
+++ b/pages/community.html
@@ -44,7 +44,7 @@ your experience with other users.
 	
 <p>
 You can contact directly the Coq developers through the
-<a class="extlink" href="https://sympa.inria.fr/sympa/info/coqdev">coqdev mailing list</a>.
+<a class="extlink" href="https://sympa.inria.fr/sympa/info/coqdev">Coqdev mailing list</a>.
 If you want to report a bug, please consider using
 our <a class="extlink" href="/bugs/">bug tracking system</a>.
 </p>
@@ -56,16 +56,16 @@ The Coq team welcomes your suggestions and improvements submitted via GitHub pul
 
 <p>
 The Coq developers and interested users gather for
-<a class="extlink" href="https://coq.inria.fr/cocorico/CoqDevelopment/">working groups</a>
+<a class="extlink" href="https://coq.inria.fr/cocorico/CoqDevelopment/">Working Groups</a>
 a few times a year.  You are welcome to attend!
 </p>
 </div>
 
 <div class="frameworklinks">
 <ul>
-<li><a href="https://sympa.inria.fr/sympa/info/coqdev">coqdev</a></li>
-<li><a class="extlink" href="/bugs/">bug tracker</a></li>
-<li><a class="extlink" href="https://coq.inria.fr/cocorico/CoqDevelopment/">working groups</a></li>
+<li><a href="https://sympa.inria.fr/sympa/info/coqdev">Coqdev</a></li>
+<li><a class="extlink" href="/bugs/">Bug tracker</a></li>
+<li><a class="extlink" href="https://coq.inria.fr/cocorico/CoqDevelopment/">Working Groups</a></li>
 </ul>
 </div>
 </div><!-- /framework -->


### PR DESCRIPTION
These are the capitalization changes Hugo requested in https://coq.inria.fr/bugs/show_bug.cgi?id=4570, except for "bug tracking", which I don't think would look right. "Coqdev" is capitalized by analogy with "Coq-club", and "Working Group" has an official status, justifying a proper noun, while "bug tracking" is just a generic sort of thing.


