### PR TITLE
Remove space from main page.

### DIFF
--- a/pages/index.html
+++ b/pages/index.html
@@ -67,8 +67,9 @@
 <p>There is a strong and active community of users working with
 Coq. They are contributing formal developments,
 extensions of Coq
-(see <a href="/packages">Coq Package Index</a>)
-, and tools based on Coq
+(see <a href="/packages">Coq Package Index</a>), 
+and tools based on Coq
+
 (see <a href="/related-tools">Related Tools</a>).
 </p>
 


### PR DESCRIPTION
Main page on [Coq website](https://coq.inria.fr) contains an extraneous space.