### PR TITLE
Adding a preliminary web-page for the CoqPL 2018 workshop.

### DIFF
--- a/pages/coq-workshop/2018PL.html
+++ b/pages/coq-workshop/2018PL.html
@@ -1,0 +1,50 @@
+<#def TITLE>The Coq Workshop 2016</#def>
+<#include "incl/header.html">
+
+<p>The 4th Coq PL Workshop</p>
+<p><em><br />
+Los Angeles, CA, USA<br />
+January 2016<br />
+(A satellite workshop of <a href="http://popl18.sigplan.org/home">PoPL 2018</a>)<br />
+</em></p>
+<p>The CoqPL workshop provides an opportunity for programming languages researchers to meet and interact with one another and members from the core Coq development team. At the meeting, we will discuss upcoming new features, see talks and demonstrations of exciting current projects, solicit feedback for potential future changes, and generally work to strengthen the vibrant community around our favorite proof assistant. Topics in scope include:</p>
+<ul>
+<li>
+    General purpose libraries and tactic language extensions</li>
+<li>
+    Domain-specific libraries for programming language formalization and verification</li>
+<li>    IDEs, profilers, tracers, debuggers, and testing tools</li>
+<li>    Experience reports from Coq usage in educational or industrial contexts</li>
+</ul>
+
+
+<p>To foster open discussion of cutting edge research which can later be published in full conference proceedings, we will not publish papers from the workshop. However, presentations will be recorded and the videos made publicly available.</p>
+<h2>Invited Talks</h2>
+
+<h2>Workshop format</h2>
+<p>The workshop format will be driven by you, members of the community. We will solicit abstracts for talks and proposals for demonstrations and flesh out format details based on responses. We expect the final program to include experiment reports, panel discussions, and invited talks (details TBA). Talks will be selected according to relevance to the workshop, based on the submission of an extended abstract.</p>
+
+<h2> Submission details</h2>
+
+<p>Submission page: <a href="https://easychair.org/conferences/?conf=coqpl2018">https://easychair.org/conferences/?conf=coqpl2018</a>.</p>
+<ul>
+<li>Submission: Monday, October 16, 2017</li>
+<li>Notification: Monday, November 6th, 2017</li>
+<li>Early Registration: TBA</li>
+<li>Workshop: TBA</li>
+</ul>
+<p>Submissions for talks and demonstrations should be described in an
+extended abstract, between 1 and 2 pages in length.  We suggset formatting the text using the two-column SIGPLAN latex style (9pt font) <a href="http://www.sigplan.org/Resources/Author/">http://www.sigplan.org/Resources/Author/</a>. </p>
+
+
+<h2>Program Committee </h2>
+<ul>
+</ul>
+
+<h2>Organization</h2>
+
+<strong>Contacts:</strong> <t>Yves.Bertot@inria.fr</t> and <t>i.sergey@ucl.ac.uk</t>
+
+<!-- <p><em>The workshop is supported by INRIA.</em></p> -->
+
+<#include "incl/footer.html">

--- a/pages/coq-workshop/index.html
+++ b/pages/coq-workshop/index.html
@@ -3,6 +3,9 @@
 
 <p>The Coq Workshop brings together Coq users, developers and contributors.  It usually consists of one-day events affiliated with larger conferences.  This series of events was started in 2009 and now contains the following workshops:</p>
 <ul>
+<li><a href="/coq-workshop/2018PL.html">2018, January, Los Angeles, CA, USA</a></li>
+<li><a href="http://conf.researchr.org/track/CoqPL-2017/main">
+2017, January 21st, Paris France</a></li>
 <li><a href="/coq-workshop/2016">2016, August 26th, Nancy, France</a></li>
 <li><a href="/coq-workshop/2015">2015, June 26th, Sophia Antipolis, France</a></li>
 <li><a href="http://coqpl.cs.washington.edu">2015, January 18th, Mumbai, India (CoqPL, affiliated to POPL)</a></li>


### PR DESCRIPTION
This commit adds a line in the web-page of coq workshops and a page for the CoqPL workshop
that will take place in January.

Local tests were performed with success.