### PR TITLE
Remove Tutorial from Download page

### DIFF
--- a/pages/download.html
+++ b/pages/download.html
@@ -109,12 +109,6 @@ and a discussion period on new features.</p>
   </tr>
 
   <tr><td colspan="3" rowspan="1" class="downloadheader">Documentation</td></tr>
-
-  <tr>
-    <td class="downloadcategory downloadbottomback" rowspan="3"></td>
-    <td class="downloadlink"><a href="/distrib/V<#CURRENTVERSION>/files/Tutorial.pdf">Tutorial.pdf</a></td>
-    <td class="downloadsize downloadback">0.2 MB</td>
-  </tr>
   
   <tr>
     <td class="downloadlink downloadbottomline"><a href="/distrib/V<#CURRENTVERSION>/files/Reference-Manual.pdf">


### PR DESCRIPTION
This was giving it more importance than is deserved.
The link to the tutorial still appears on the Documentation page.

(I was suggested this removal by Hugo.)