### PR TITLE
Updating citing Coq in FAQ.

### DIFF
--- a/pages/faq.html
+++ b/pages/faq.html
@@ -3979,15 +3979,14 @@ You can use <tt> coq_tex</tt> .<br/>
 
 <h4 class="subsubsection"><a name="htoc168">146</a>&nbsp;&nbsp;How can I cite the <span class="caps">Coq</span> reference manual?</h4><!--SEC END -->
 
-You can use this bibtex entry:
+You can use this bibtex entry (to adapt to the appropriate version):
 <pre class="verbatim">
-@Manual{Coq:manual,
-  title =        {The Coq proof assistant reference manual},
-  author =       {\mbox{The Coq development team}},
-  organization = {LogiCal Project},
-  note =         {Version 8.0},
-  year =         {2004},
-  url =          "http://coq.inria.fr"
+@manual{Coq:manual,
+  author      = {{Coq} {Development} {Team}, The},
+  title       = {The {Coq} Proof Assistant Reference Manual, version 8.6},
+  month       = Dec,
+  year        = {2016},
+  url         = {http://coq.inria.fr}
 }
 </pre>
 <!--TOC subsubsection Where can I publish my developments in <span class="caps">Coq</span>?-->


### PR DESCRIPTION
This is [BZ5766](https://coq.inria.fr/bugs/show_bug.cgi?id=5766) for its website part.