### PR TITLE
Make download links point to download page instead of GitHub

### DIFF
--- a/incl/header.html
+++ b/incl/header.html
@@ -18,7 +18,7 @@
         <ul class="links">
           <li><a href="/">Home</a></li>
           <li><a href="/about-coq">About Coq</a></li>
-          <li><a href="<#RELEASES>">Get Coq</a></li>
+          <li><a href="/download">Get Coq</a></li>
           <li><a href="/documentation">Documentation</a></li>
           <li><a href="/community">Community</a></li>
           <li><a href="/consortium">Consortium</a></li>

--- a/pages/about-coq.html
+++ b/pages/about-coq.html
@@ -1,5 +1,4 @@
-<#def TITLE>What is Coq?</#def>
-<#include "incl/header.html">
+<#def TITLE>What is Coq?</#def><#include "incl/header.html">
 
 <div class="framework">
 <div class="frameworklabel">Handling proofs and programs</div>
@@ -53,7 +52,7 @@
 
 <div class="frameworklinks">
 <ul>
-<li><a href="<#RELEASES>">Get Coq!</a></li>
+<li><a href="/download">Get Coq!</a></li>
 </ul>
 </div>
 

--- a/pages/index.html
+++ b/pages/index.html
@@ -19,7 +19,7 @@
 
 
 <div class="framework">
-<div class="frameworklabel"><a style="color:black;font-weight:bold" href="<#RELEASES>">How to get it ?</a></div>
+<div class="frameworklabel"><a style="color:black;font-weight:bold" href="/download">How to get it ?</a></div>
 <div class="frameworkcontent">
   <p>You can download <a href="<#CURRENTVERSIONURL>">the current stable version,
       Coq <#CURRENTVERSION></a>, released in <#CURRENTVERSIONDATE>. It features


### PR DESCRIPTION
This follows a suggestion by @Zimmi48.