### PR TITLE
Update links to documentation.

### DIFF
--- a/pages/documentation.html
+++ b/pages/documentation.html
@@ -14,7 +14,6 @@
   href="/distrib/current/stdlib">Standard Library</a> distributed
   with the system.</li>
 </ul>
-<p>A PDF version of the Reference Manual is available on <a href="https://github.com/coq/coq/releases/latest">the release page</a>.</p>
 </div>
 
 <div class="frameworklinks">
@@ -51,9 +50,9 @@
     on Recursive Types in Coq</a> (Eduardo Giménez, Pierre Castéran,
     2006) and the associated <a
     href="http://www.labri.fr/perso/casteran/RecTutorial.v">examples</a>;</li>
-    <li> a bunch of <a href="/faq">Frequently Asked
+    <li> a bunch of <a href="https://github.com/coq/coq/wiki/The-Coq-FAQ">Frequently Asked
     Questions</a>;</li>
-    <li><a href="/cocorico/">Cocorico!</a>, the Coq wiki;</li>
+    <li><a href="https://github.com/coq/coq/wiki/">Cocorico!</a>, the Coq wiki;</li>
  <li><a
     href="http://www.labri.fr/perso/casteran/CoqArt/TypeClassesTut/typeclassestut.pdf">A Gentle Introduction
     to Type Classes and Rewriting in Coq</a> (Pierre Castéran, Matthieu Sozeau, 
@@ -66,10 +65,8 @@
   <ul>
     <li><a href="http://www.labri.fr/perso/casteran/CoqArt/">Coq'Art</a></li>
     <li><a href="https://cel.archives-ouvertes.fr/inria-00001173">Coq in a Hurry</a></li>
-    <li><a href="/tutorial">Tutorial</a></li>
-    <li><a href="http://www.labri.fr/perso/casteran/RecTutorial.pdf">Recursive Types</a></li>
-    <li><a href="/faq">F.A.Q.</a></li>
-    <li><a href="/cocorico/">Cocorico!</a></li>
+    <li><a href="https://github.com/coq/coq/wiki/The-Coq-FAQ">F.A.Q.</a></li>
+    <li><a href="https://github.com/coq/coq/wiki/">Cocorico! (wiki)</a></li>
   </ul>
 </div>
 </div><!-- /framework -->


### PR DESCRIPTION
Do not mention PDF version of the refman since it doesn't exist anymore (closes coq/coq#7454).
Use direct links to Cocorico and the FAQ.
Remove prominent links to the Tutorial and the RecTutorial (but keep the in the full list).

I'll self-merge in a few days if no comments.