### PR TITLE
Add link to the master branch version of the refman.

### DIFF
--- a/pages/documentation.html
+++ b/pages/documentation.html
@@ -14,6 +14,8 @@
   href="/distrib/current/stdlib">Standard Library</a> distributed
   with the system.</li>
 </ul>
+<p> You can also get access to the
+  <a href="https://gitlab.com/coq/coq/-/jobs/artifacts/master/file/_install_ci/share/doc/coq/sphinx/html/index.html?job=build:base">Reference Manual for Coq's development version</a>.</p>
 </div>
 
 <div class="frameworklinks">


### PR DESCRIPTION
Add link to the master branch version of the refman. Thanks to GitLab CI artifacts.
We use a canonical URL that will always point to the latest build artifact.
Note that currently, the displayed version number is still 8.8+alpha because coq/coq#7008 was not merged yet.

We could also link to the development version of the stdlib doc (see https://gitlab.com/coq/coq/-/jobs/artifacts/master/file/_install_ci/share/doc/coq/html/stdlib/index.html?job=build:base) but I don't do it in this PR because the rendering is disastrous. Note that this is the version that is installed with `make install-doc`. We should improve the rendering (by shipping the CSS) and remove the top links that do not make sense when not accessed through the official website.