### PR TITLE
Add minimal default.nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,17 @@
+{ pkgs ? (import <nixpkgs> {})
+, ocamlPackages ? pkgs.ocaml-ng.ocamlPackages_4_06
+}:
+
+with pkgs;
+
+stdenv.mkDerivation rec {
+
+  name = "coq_website";
+  src = null;
+
+  buildInputs = [
+    ocaml
+    python3
+  ];
+
+}


### PR DESCRIPTION
This is already useful for NixOS users, and will probably be expanded
once we switch to a more standard toolchain (e.g. Jekyll)