### PR TITLE
adds 2018 Coq FLoC and 2019 CoqPL workshops in the list

### DIFF
--- a/pages/coq-workshop/index.html
+++ b/pages/coq-workshop/index.html
@@ -3,9 +3,11 @@
 
 <p>The Coq Workshop brings together Coq users, developers and contributors.  It usually consists of one-day events affiliated with larger conferences.  This series of events was started in 2009 and now contains the following workshops:</p>
 <ul>
+<li><a href="https://popl19.sigplan.org/track/CoqPL-2019">2019, January 19th, Lisbon Portugal</a></li>
+<li><a href="https://coqworkshop2018.inria.fr/">2018, July 8th, Oxford, UK</a></li>
 <li><a href="/coq-workshop/2018PL.html">2018, January, Los Angeles, CA, USA</a></li>
 <li><a href="http://conf.researchr.org/track/CoqPL-2017/main">
-2017, January 21st, Paris France</a></li>
+2017, January 21st, Paris, France</a></li>
 <li><a href="/coq-workshop/2016">2016, August 26th, Nancy, France</a></li>
 <li><a href="/coq-workshop/2015">2015, June 26th, Sophia Antipolis, France</a></li>
 <li><a href="http://coqpl.cs.washington.edu">2015, January 18th, Mumbai, India (CoqPL, affiliated to POPL)</a></li>


### PR DESCRIPTION
This change was tested by typing

    make
    make run
and checking that the new links were valid.