### PR TITLE
Add OPAM documentation

### DIFF
--- a/pages/download.html
+++ b/pages/download.html
@@ -13,7 +13,7 @@
 
 <p>
 We also provide instructions on
-<a href="/opam/www/using.html">
+<a href="/opam-using.html">
 how to install Coq and related packages via OPAM
 </a>
 step by step on MacOS and Linux.

--- a/pages/opam-layout.html
+++ b/pages/opam-layout.html
@@ -1,0 +1,27 @@
+<#def TITLE>Layout of the Coq Package Index</#def>
+<#include "incl/header.html">
+<p>The archive is organized in the following OPAM repositories.</p>
+
+<h2>released</h2>
+
+<p>The repository contains packages for Coq and for Coq extensions that were
+officially released by the Coq team or their corresponding authors.
+All packages have a version number (i.e. no .dev packages).
+The repository is self contained.
+The repository is intended to be used by people familiar with the OPAM
+tool.</p>
+
+<h2>core-dev</h2>
+
+<p>The repository contains package for development versions of Coq. Typically
+.dev packages for Coq branches. The repository is self contained. The
+repository is intended to be used by developers only.</p>
+
+<h2>extra-dev</h2>
+
+<p>The repository contains packages for development versions of external
+contributions to Coq. Typically .dev packages following the branches of the
+extension. The repository is not self contained, i.e. a package may depend on
+a development version of Coq part of the <code>core-dev</code> repository. The repository
+is intended to be used by developers only.</p>
+<#include "incl/footer.html">

--- a/pages/opam-packaging.html
+++ b/pages/opam-packaging.html
@@ -1,0 +1,172 @@
+<#def TITLE>Creating and Submitting a Package</#def>
+<#include "incl/header.html">
+<p>This page contains instructions covering the case of a simple Coq package
+called <code>foo</code> with version <code>1.0.0</code>.
+The full documentation on OPAM packages can be found on the <a href="http://opam.ocaml.org/">OPAM web site</a>.</p>
+
+<h2>Creating a package</h2>
+
+<p>First, go to the github page of <a href="https://github.com/coq/opam-coq-archive">opam-coq-archive</a> and <a href="https://help.github.com/articles/fork-a-repo/">make a fork</a>.</p>
+
+<p>The repository is now available in your personal github space.
+Clone it locally by typing the following, where <code>user</code> is your github user name.</p>
+
+<pre><code>git clone git@github.com:user/opam-coq-archive.git
+cd opam-coq-archive
+</code></pre>
+
+<p>Note that the correct URL can also be found by clicking on the <em>clone</em> <em>or</em>
+<em>download</em> button. Then create a directory named as follows</p>
+
+<pre><code>mkdir -p released/packages/coq-foo/coq-foo.1.0.0
+</code></pre>
+
+<p>Remark that the package for <code>foo</code> is named <code>coq-foo</code> and that the directory
+name is the package name followed by a dot followed by the version of the
+package. Such directory has to contain at least 3 files</p>
+
+<p>First, a text file called <code>url</code> pointing to the sources archive.
+In our case <code>released/packages/coq-foo/coq-foo.1.0.0/url</code> contains:</p>
+
+<pre><code>http: &quot;https://github.com/user/foo/archive/1.0.0.tar.gz&quot;
+checksum: &quot;d41d8cd98f00b204e9800998ecf8427e&quot;
+</code></pre>
+
+<p>The MD5 checksum is mandatory, and can be obtained with:</p>
+
+<pre><code>curl -L https://github.com/user/foo/archive/1.0.0.tar.gz | md5sum
+</code></pre>
+
+<p>Second, a text file called <code>descr</code> containing a short
+description of the package. In our case the contents of
+<code>released/packages/coq-foo/coq-foo.1.0.0/descr</code> are:</p>
+
+<pre><code>Foo is a Coq library doing wonders
+</code></pre>
+
+<p>Third, a text file called <code>opam</code> containing some metadata like build
+instructions and dependencies. In our case
+<code>released/packages/coq-foo/coq-foo.1.0.0/opam</code> contains:</p>
+
+<pre><code>opam-version: &quot;1.2&quot;
+maintainer: &quot;your@email.address&quot;
+homepage: &quot;https://github.com/you/foo&quot;
+dev-repo: &quot;https://github.com/you/foo.git&quot;
+bug-reports: &quot;https://github.com/you/foo/issues&quot;
+authors: [&quot;Your Name&quot;]
+license: &quot;MIT&quot;
+build: [
+  [&quot;coq_makefile -R . Foo -o Makefile *.v&quot;]
+  [make &quot;-j%{jobs}%&quot;]
+]
+install: [
+  [make &quot;install&quot;]
+]
+remove: [&quot;rm&quot; &quot;-R&quot; &quot;%{lib}%/coq/user-contrib/Foo&quot;]
+depends: [
+  &quot;coq&quot; {&gt;= &quot;8.5&quot; &amp; &lt; &quot;8.6~&quot;}
+]
+tags: [
+  &quot;keyword:fooish&quot;
+  &quot;category:Miscellaneous/Coq Extensions&quot;
+  &quot;date:2016-09-01&quot;
+  &quot;logpath:Foo&quot;
+]
+</code></pre>
+
+<p>One can now git commit the new package</p>
+
+<pre><code>git add released/packages/coq-foo/coq-foo.1.0.0
+git commit -m 'Packaging foo version 1.0.0'
+</code></pre>
+
+<h2>Testing your new package</h2>
+
+<p>The preliminary step is to lint your <code>opam</code> file as follows</p>
+
+<pre><code>opam lint released/packages/coq-foo/coq-foo.1.0.0/opam
+</code></pre>
+
+<p>Once no more errors are given, the best way to test your package is to add your
+local clone of <code>opam-coq-archive</code> to opam as follows, and then run <code>opam
+install</code> on your new package in verbose mode:</p>
+
+<pre><code>opam repo add test ./released
+opam install -v coq-foo
+</code></pre>
+
+<p>If things go wrong, after having fixed the problem and before trying again
+to install the package you shall run <code>opam update</code>.</p>
+
+<h2>Submitting your new package</h2>
+
+<p>Submission happens by <a href="https://help.github.com/articles/creating-a-pull-request/">creating a pull request</a>
+ on the <a href="https://github.com/coq/opam-coq-archive">opam-coq-archive repository</a>.</p>
+
+<p>First push your changes to you personal fork</p>
+
+<pre><code>git push origin master
+</code></pre>
+
+<p>Then visit the github page of your personal fork and click on the
+<em>new</em> <em>pull</em> <em>request</em> button.</p>
+
+<h2>Making good packages</h2>
+
+<h3>Conventions</h3>
+
+<ol>
+<li>The archive follows a <a href="opam-layout.html">layout</a>.
+Regular packages shall be placed in the <code>released</code> directory.
+One can also write packages that install development branches of
+a software. In that case <code>extra-dev</code> directory has to be used
+and the version has to end in <code>dev</code> like <code>mybranch.dev</code>.</li>
+<li>The package name should start with <code>coq-</code>, for example <code>coq-color</code> or
+<code>coq-interval</code>.</li>
+<li>The <code>tags</code> field in the <code>opam</code> file can contain additional metadata
+(like a categorization or the Coq logical path the package populates)
+as described in <a href="https://github.com/coq/ceps/blob/master/text/003-opam-metadata.md">CEP3</a></li>
+</ol>
+
+<h3>Rules of thumb</h3>
+
+<p>The released repository shall contain software that works with a stable version
+of Coq. Packages are maintained by their corresponding authors or by the Coq
+team. Dependencies must be expressed in a conservative way providing both
+lower and upper bounds to version numbers. This way all installable packages
+(i.e. with satisfiable constraints) shall compile successfully.</p>
+
+<p>We advise package authors to make sure that the following conditions are
+met:</p>
+
+<ol>
+<li><em>Maintained</em> by the Coq team or by an external author (contact email
+address in the <code>author:</code> field in OPAM metadata)</li>
+<li><em>Released</em> with a version number and a tar ball (that is mirrored on the Coq
+OPAM archive website)</li>
+<li>Includes a <em>Changelog</em> that lists the main changes between any
+two versions part of this archive</li>
+<li>The <em>License</em> must allow free redistribution (even if it is not a free
+software license)</li>
+<li><em>No</em> <em>Admitted</em> proofs</li>
+<li>All <em>Axioms</em> used are documented</li>
+<li>ML code is <em>reviewed</em> by a Coq developer</li>
+<li><em>Documentation</em> should be available (see the <code>doc:</code> field in the
+OPAM metadata)</li>
+</ol>
+
+<p>In any case the Coq development team keeps the right to refuse the integration
+of a package or remove any package at any time.</p>
+
+<h3>Updating a package to a new version</h3>
+
+<ol>
+<li>Like the initial version, the new version of the package should be
+submitted in a pull request and is encouraged to follow the
+guidelines above</li>
+<li>We recommend to ease the transition from the old to the new version by
+providing a transition strategy (a document helping a user to perform the
+switch: e.g. documenting all renamings).</li>
+<li>The old version stays in the repository.</li>
+</ol>
+<#include "incl/footer.html">

--- a/pages/opam-using.html
+++ b/pages/opam-using.html
@@ -1,0 +1,73 @@
+<#def TITLE>Installing Coq via OPAM</#def>
+<#def OCAMLV>4.02.3</#def>
+<#include "incl/macros.html">
+<#include "incl/header.html">
+<h2>What is OPAM</h2>
+
+<p>OPAM is the package manager for the OCaml programming language, the language
+in which Coq is implemented.
+Instructions on
+<a href="http://opam.ocaml.org/doc/Install.html">how to install OPAM</a>
+itself are available on the OPAM website.</p>
+
+<p>By following the instructions on this web page one installs the last stable
+version of Coq and all additional packages in the directory <code>~/opam-coq.<#CURRENTVERSION></code>.
+Instructions target an OPAM newcomer.</p>
+
+<h2>Using OPAM to install Coq</h2>
+
+<p>Once the <code>opam</code> command is available, i.e. OPAM is installed, one can
+proceed as follows (using opam 2):</p>
+
+<pre><code>export OPAMROOT=~/opam-coq.<#CURRENTVERSION> # installation directory
+opam init -n --comp=ocaml-base-compiler.<#OCAMLV> -j 2 # 2 is the number of CPU cores
+opam repo add coq-released http://coq.inria.fr/opam/released
+opam install coq.<#CURRENTVERSION> &amp;&amp; opam pin add coq <#CURRENTVERSION>
+</code></pre>
+
+<p>If using <code>opam 1.2</code>, the <code>init</code> command should be:</p>
+
+<pre><code>opam init -n --comp <#OCAMLV>
+</code></pre>
+
+<p>One may also want to install CoqIDE. Note that this requires GTK+ development
+files (gtksourceview2) to be available on the system.</p>
+
+<pre><code>opam install coqide
+</code></pre>
+
+<p>For alternative user interfaces / editors, see instructions on their own
+homepage, e.g. <a href="https://proofgeneral.github.io/#quick-installation-instructions">https://proofgeneral.github.io/#quick-installation-instructions</a>
+for Proof-General.</p>
+
+<h2>Running Coq</h2>
+
+<p>Every time a new shell is opened one has to type in the following lines
+in order to use Coq</p>
+
+<pre><code>export OPAMROOT=~/opam-coq.<#CURRENTVERSION>
+eval `opam config env`
+</code></pre>
+
+<p>After that <code>coqc -v</code> shall run and print the version of Coq.</p>
+
+<h2>Using OPAM to install Coq packages</h2>
+
+<p>If Coq has been installed as described above, the list of available Coq
+packages can be accessed as follows</p>
+
+<pre><code>opam search coq
+</code></pre>
+
+<p>The command lists the Coq package names followed by a short description.
+One can access a more detailed description of a package, say <code>coq-sudoku</code>,
+by typing</p>
+
+<pre><code>opam show coq-sudoku
+</code></pre>
+
+<p>One can install the package by typing</p>
+
+<pre><code>opam install coq-sudoku
+</code></pre>
+<#include "incl/footer.html">

--- a/pages/packages.html
+++ b/pages/packages.html
@@ -17,7 +17,7 @@ can be <a href="/opam/www">browsed online</a>.
 
 <p>
 We provide instructions on 
-<a href="/opam/www/using.html">
+<a href="/opam-using.html">
 how to install Coq and related packages via OPAM
 </a>
 step by step.
@@ -26,14 +26,14 @@ step by step.
 
 <p>
 You are encouraged to make your Coq developments visible and easily installable
-by <a href="/opam/www/packaging.html">submitting them to the Coq Package Index</a>.
+by <a href="/opam-packaging.html">submitting them to the Coq Package Index</a>.
 </p>
 
 </div>
 <div class="frameworklinks">
 <ul>
 <li><a href="/opam/www">Browse the index</a></li>
-<li><a href="/opam/www/packaging.html">Submit a new package</a></li>
+<li><a href="/opam-packaging.html">Submit a new package</a></li>
 </ul>
 </div>
 </div>


### PR DESCRIPTION
I believe this information belongs to this repository rather than to the `opam-coq-archive` which gathers the data.

Also, having the source of the static part of the web site scattered across several repositories is less convenient (for maintenance, deployment, etc.).