### PR TITLE
Advertise Discourse and rework community page.

### DIFF
--- a/pages/community.html
+++ b/pages/community.html
@@ -2,85 +2,137 @@
 <#include "incl/header.html">
 
 <div class="framework">
-<div class="frameworklabel">The users of Coq</div>
-
+<div class="frameworklabel">Questions and discussion</div>
 <div class="frameworkcontent">
 
 <p>
-The Coq community has contributed a large ecosystem of formalization works and plugins throughout the years.
-An index of OPAM packages can be <a href="/opam/www">browsed online</a>.
-Users are encouraged to <a href="/packages">submit their packages to the index</a>.
+Get in touch with the user community and ask questions about Coq on
+our <a href="https://coq.discourse.group">Discourse forum</a>. Posts
+in other languages than English are explicitly welcome there. There is
+also a historic mailing list called the
+<a href="https://sympa.inria.fr/sympa/arc/coq-club">Coq-Club</a>
+which has lots of subscribers.
 </p>
 
 <p>
-The Coq community has also built tools around the Coq system.
-You can also visit the page dedicated to <a href="related-tools">related tools</a>.
+In addition, you may also ask questions about Coq on Stack Overflow (use
+the tag <a href="https://stackoverflow.com/questions/tagged/coq">coq</a>)
+or on the meta-theory of Coq on the
+<a href="https://cstheory.stackexchange.com">TCS Stack Exchange</a> (which also
+has a <a href="https://cstheory.stackexchange.com/questions/tagged/coq">coq</a>
+tag).
 </p>
 
 <p>
-You can interact with other users of Coq through the 
-<a class="extlink" href="https://sympa.inria.fr/sympa/info/coq-club">Coq-club mailing list</a>;
-the <a href="https://sympa.inria.fr/sympa/arc/coq-club">list archives</a> are 
-also a good source of information but they are hard to browse.  There is also a wiki dedicated to Coq:
-<a class="extlink" href="/cocorico/">Cocorico!</a>, where you can share 
-your experience with other users.
-</p>
-
-<p>
-You can ask questions on how to use Coq on
-<a class="extlink" href="https://stackoverflow.com/questions/tagged/coq">StackOverflow</a>
-and questions on the meta-theory of Coq on
-<a class="extlink" href="https://cstheory.stackexchange.com/questions/tagged/coq">Theoretical Computer Science SE</a>.
-The advantages of these platforms over the mailing list are that they are easier to browse and allow
-answers to be amended over time.
-If you wish to answer questions on Coq on these platforms, you can
-<a class="extlink" href="https://stackexchange.com/filters/299857/questions-tagged-coq-on-stackexchange-sites">
-browse questions tagged Coq over all the Stack Exchange sites</a>.
+You can reach the Coq development team through the
+<a href="https://coq.discourse.group/c/coq-development">development category</a>
+of the above mentioned Discourse forum,
+the <a href="https://gitter.im/coq/coq">Gitter channel</a>, and of course
+the <a href="https://github.com/coq/coq/issues">bug tracker</a>.
 </p>
 
 </div>
 
 <div class="frameworklinks">
 <ul>
-<li><a href="/packages">Coq Package Index</a></li>
-<li><a href="/related-tools">Related Tools</a></li>
-<li><a href="https://sympa.inria.fr/sympa/arc/coq-club">Coq-club</a></li>
-<li><a class="extlink" href="/cocorico/">Cocorico!</a></li>
+<li><a href="https://coq.discourse.group">Discourse forum</a></li>
+<li><a href="https://sympa.inria.fr/sympa/arc/coq-club">Coq-Club</a></li>
 <li><a class="extlink" href="https://stackoverflow.com/questions/tagged/coq">StackOverflow</a></li>
+<li><a class="extlink" href="https://gitter.im/coq/coq">Gitter</a></li>
 </ul>
 </div>
 </div>
 
 <div class="framework">
-  <div class="frameworklabel">The Coq development team</div>
+<div class="frameworklabel">Package ecosystem</div>
 <div class="frameworkcontent">
-	
+
 <p>
-You can contact the Coq developers directly through the
-<a class="extlink" href="https://sympa.inria.fr/sympa/info/coqdev">Coqdev mailing list</a>
-or through <a class="extlink" href="https://gitter.im/coq/coq">Coq Gitter chat</a>.
-If you want to report a bug, please consider using
-our <a class="extlink" href="/bugs/">bug tracking system</a>.
+The Coq user community has contributed a large ecosystem of
+formalization works and plugins throughout the years. An index of
+packages can be <a href="/opam/www">browsed online</a>. Installing
+them can be done using the <a href="/opam-using.html">opam</a> package
+manager. Some of these packages are also bundled in the Windows
+installer.</p>
+
+<p>Users are encouraged to <a href="/opam-packaging.html">submit their
+packages to the index</a>. They are also encouraged
+to <a href="https://github.com/coq/coq/blob/master/dev/ci/README-users.md">add
+their projects to Coq's Continuous Integration</a>. In particular, for
+authors of projects that link to Coq's ML API (a.k.a. plugins), this
+can be really useful as it allows getting updates from the development
+team when the (unstable) ML API receives breaking changes.
 </p>
 
 <p>
-You can follow the Coq development process at the Coq <a href="https://github.com/coq/coq/">GitHub repository</a>.
-The Coq team welcomes your suggestions and improvements submitted via GitHub pull requests.
+The user community has also built tools around the Coq system and
+contributed a lot of documentation. Visit the pages dedicated
+to <a href="/related-tools.html">related tools</a>
+and <a href="/documentation.html">documentation</a>.
 </p>
 
 <p>
-Coq developers and interested users gather for
-<a class="extlink" href="https://coq.inria.fr/cocorico/CoqDevelopment/">Working Groups</a>
-a few times a year.  You are welcome to attend!
+An informal organization of users,
+called <a href="https://github.com/coq-community/manifesto">coq-community</a>,
+exists to ensure the long term maintenance of Coq packages, and favor
+other collaborative projects such as documentation writing. It is
+always looking for new volunteers.
 </p>
+
 </div>
 
 <div class="frameworklinks">
 <ul>
-<li><a href="https://sympa.inria.fr/sympa/info/coqdev">Coqdev</a></li>
-<li><a class="extlink" href="https://gitter.im/coq/coq">Gitter</a></li>
-<li><a class="extlink" href="/bugs/">Bug tracker</a></li>
-<li><a class="extlink" href="https://coq.inria.fr/cocorico/CoqDevelopment/">Working Groups</a></li>
+<li><a href="/packages.html">Coq Package Index</a></li>
+<li><a href="https://github.com/coq/coq/blob/master/dev/ci/README-users.md">Coq's CI</a></li>
+<li><a href="https://github.com/coq-community/manifesto">coq-community</a></li>
+<li><a href="/related-tools.html">Related Tools</a></li>
+</ul>
+</div>
+</div>
+
+<div class="framework">
+<div class="frameworklabel">Events</div>
+<div class="frameworkcontent">
+	
+<p>
+Coq developers and interested users gather every month through visio-conference for
+<a href="https://github.com/coq/coq/wiki/Coq-Working-Groups">Working
+Groups</a>. You are welcome to attend!
+</p>
+
+<p>
+The Coq development team organizes a
+one-week-long <a href="https://github.com/coq/coq/wiki/CoqImplementorsWorkshop">Implementors
+Workshop</a> every year in France. The goal is to help users become
+contributors by guiding them and answering their questions.
+</p>
+
+<p>
+Other yearly events:
+<ul>
+<li><a href="/coq-workshop">Coq Workshops (generally colocated with ITP)</a></li>
+<li><a href="/coqpl.html">CoqPL workshops (colocated with POPL)</a></li>
+<li><a href="https://deepspec.org/page/Event/">DeepSpec Summer Schools</a></li>
+</ul>
+</p>
+
+<p>
+Coq Meetups:
+<ul>
+<li><a href="https://www.meetup.com/Austin-Types-Theorems-and-Programming-Languages/">Austin
+Types, Theorems, and Programming Languages</a></li>
+<li><a href="https://www.meetup.com/Coq-Users-in-PariS/">Coq Users in PariS</a></li>
+</ul>
+</p>
+
+</div>
+<div class="frameworklinks">
+<ul>
+<li><a href="https://github.com/coq/coq/wiki/Coq-Working-Groups">Working Groups</a></li>
+<li><a href="https://github.com/coq/coq/wiki/CoqImplementorsWorkshop">Implementors Workshops</a></li>
+<li><a href="/coq-workshop">Coq Workshops</a></li>
+<li><a href="/coqpl.html">CoqPL</a></li>
 </ul>
 </div>
 </div><!-- /framework -->

--- a/pages/coq-workshop/index.html
+++ b/pages/coq-workshop/index.html
@@ -1,16 +1,13 @@
 <#def TITLE>The Coq Workshop</#def>
 <#include "incl/header.html">
 
-<p>The Coq Workshop brings together Coq users, developers and contributors.  It usually consists of one-day events affiliated with larger conferences.  This series of events was started in 2009 and now contains the following workshops:</p>
+<p>The Coq Workshop brings together Coq users, developers and
+contributors.  It is a one-day event, held virtually every year since
+2009, and generally affiliated with ITP.</p>
 <ul>
-<li><a href="https://popl19.sigplan.org/track/CoqPL-2019">2019, January 19th, Lisbon Portugal</a></li>
 <li><a href="https://coqworkshop2018.inria.fr/">2018, July 8th, Oxford, UK</a></li>
-<li><a href="/coq-workshop/2018PL.html">2018, January, Los Angeles, CA, USA</a></li>
-<li><a href="http://conf.researchr.org/track/CoqPL-2017/main">
-2017, January 21st, Paris, France</a></li>
 <li><a href="/coq-workshop/2016">2016, August 26th, Nancy, France</a></li>
 <li><a href="/coq-workshop/2015">2015, June 26th, Sophia Antipolis, France</a></li>
-<li><a href="http://coqpl.cs.washington.edu">2015, January 18th, Mumbai, India (CoqPL, affiliated to POPL)</a></li>
 <li><a href="http://www.easychair.org/smart-program/VSL2014/Coq-index.html">2014, July 18th, Vienna, Austria</a></li>
 <li><a href="/coq-workshop/2013">2013, July 22nd, Rennes, France</a></li>
 <li><a href="/coq-workshop/2012">2012, August, Princeton, NJ, USA</a></li>

--- a/pages/coqpl.html
+++ b/pages/coqpl.html
@@ -1,0 +1,21 @@
+<#def TITLE>The CoqPL Workshop</#def>
+<#include "incl/header.html">
+
+<p>The CoqPL Workshop brings together Coq users, developers and
+contributors. It is a one-day event, held every year since 2015, at
+POPL.</p>
+<ul>
+<li><a href="https://popl19.sigplan.org/track/CoqPL-2019">2019,
+January 19th, Lisbon Portugal</a></li>
+<li><a href="https://popl18.sigplan.org/track/CoqPL-2018">2018,
+January 13th, Los Angeles, CA, USA</a></li>
+<li><a href="https://popl17.sigplan.org/track/main">2017,
+January 21st, Paris, France</a></li>
+<li><a href="https://conf.researchr.org/home/CoqPL-2016">2016, January
+23rd, St. Petersburg, FA, USA</a></li>
+<li><a href="http://coqpl.cs.washington.edu">2015, January 18th,
+Mumbai, India</a></li>
+</ul>
+<p><em>The workshop is supported by Inria.</em></p>
+
+<#include "incl/footer.html">

--- a/pages/index.html
+++ b/pages/index.html
@@ -4,7 +4,7 @@
 <#include "incl/header.html">
 
 <div class="framework">
-<div class="frameworklabel"><a style="color:black;font-weight:bold" href="/about-coq">What is Coq ?</a></div>
+<div class="frameworklabel"><a style="color:black;font-weight:bold" href="/about-coq">What is Coq?</a></div>
 <div class="frameworkcontent">
   <p>Coq is a formal proof management system. It provides a formal language to write mathematical definitions, executable algorithms and theorems together with an environment for semi-interactive development of machine-checked proofs. Typical applications include the <a href="/cocorico/List%20of%20Coq%20PL%20Projects">certification of properties of programming languages</a> (e.g. the <a href="http://compcert.inria.fr">CompCert</a> compiler certification project, or the <a href="http://plv.csail.mit.edu/bedrock/">Bedrock</a> verified low-level programming library), the <a href="/cocorico/List%20of%20Coq%20Math%20Projects">formalization of mathematics</a> (e.g. the full formalization of the <a href="https://hal.inria.fr/hal-00816699">Feit-Thompson theorem</a> or <a href="http://homotopytypetheory.org/coq/">homotopy type theory</a>) and <a href="/cocorico/CoqInTheClassroom">teaching</a>.
   </p>
@@ -19,7 +19,7 @@
 
 
 <div class="framework">
-<div class="frameworklabel"><a style="color:black;font-weight:bold" href="/download">How to get it ?</a></div>
+<div class="frameworklabel"><a style="color:black;font-weight:bold" href="/download">How to get it?</a></div>
 <div class="frameworkcontent">
   <p>You can download <a href="<#CURRENTVERSIONURL>">the current stable version,
       Coq <#CURRENTVERSION></a>, released in <#CURRENTVERSIONDATE>. It
@@ -41,7 +41,7 @@
 </div>
 
 <div class="framework">
-<div class="frameworklabel">How to contribute ?</div>
+<div class="frameworklabel"><a  style="color:black;font-weight:bold" href="https://github.com/coq/coq/blob/master/CONTRIBUTING.md">How to contribute?</a></div>
 <div class="frameworkcontent">
     <p>You can contribute to the development of Coq by reporting bugs,
     submitting pull requests, improving the documentation, and in many other
@@ -52,6 +52,7 @@
 
 <div class="frameworklinks">
 <ul>
+<li><a href="/bugs/">Bug tracker</a></li>
 <li><a href="https://github.com/coq/coq/blob/master/CONTRIBUTING.md">Contributing guide</a></li>
 <li><a href="/consortium">Coq Consortium</a></li>
 </ul>
@@ -81,25 +82,25 @@
 
 
 <div class="framework">
-<div class="frameworklabel"><a style="color:black;font-weight:bold" href="/community">The Coq Community</a></div>
+<div class="frameworklabel"><a style="color:black;font-weight:bold" href="/community.html">The Coq Community</a></div>
 <div class="frameworkcontent">
 
 <p>There is a strong and active community of users working with
 Coq. They are contributing formal developments,
 extensions of Coq
-(see <a href="/packages">Coq Package Index</a>),
+(see <a href="/packages.html">Coq Package Index</a>),
 and tools based on Coq
-(see <a href="/related-tools">Related Tools</a>).
+(see <a href="/related-tools.html">Related Tools</a>).
+We have an active (multi-lingual) <a href="https://coq.discourse.group">Discourse forum</a>.
 </p>
 
 </div>
 
 <div class="frameworklinks">
 <ul>
-<li><a href="/coq-workshop">Coq Workshop</a></li>
-<li><a href="/packages">Coq Package Index</a></li>
-<li><a href="/bugs/">Bug tracker</a></li>
-<li><a href="/community">Community</a></li>
+<li><a href="/packages.html">Coq Package Index</a></li>
+<li><a href="https://coq.discourse.group">Discourse forum</a></li>
+<li><a href="/community.html">Community</a></li>
 </ul>
 </div>
 </div><!-- /framework -->


### PR DESCRIPTION
What is missing: I'm intending to clearly separate the Coq workshops and CoqPL workshops and make sure that the list is exhaustive.