### PR TITLE
Start listing Coq schools in the community page.

### DIFF
--- a/pages/community.html
+++ b/pages/community.html
@@ -109,11 +109,20 @@ contributors by guiding them and answering their questions.
 </p>
 
 <p>
-Other yearly events:
+Other Coq workshops and schools:
 <ul>
 <li><a href="/coq-workshop">Coq Workshops (generally colocated with ITP)</a></li>
 <li><a href="/coqpl.html">CoqPL workshops (colocated with POPL)</a></li>
-<li><a href="https://deepspec.org/page/Event/">DeepSpec Summer Schools</a></li>
+<li><a href="https://team.inria.fr/marelle/en/teaching/">Coq / Math-Comp Winter Schools</a></li>
+<li>DeepSpec Summer
+Schools(<a href="https://deepspec.org/event/dsss17/">2017
+edition</a>; <a href="https://deepspec.org/event/dsss18/">2018
+edition</a>)</li>
+<li>School and Workshop on Univalent Mathematics
+(<a href="https://unimath.github.io/bham2017/">2017
+edition</a>; <a href="https://unimath.github.io/bham2019/">2019
+edition</a>)</li>
+<li><a href="/other-events.html">Other past or non-recurring events</a></li>
 </ul>
 </p>
 

--- a/pages/other-events.html
+++ b/pages/other-events.html
@@ -1,0 +1,32 @@
+<#def TITLE>Other past events</#def>
+<#include "incl/header.html">
+
+<p>We list here various past tutorials, schools, and other
+non-recurring (or now inactive) events around Coq:</p>
+<ul>
+<li><a href="https://sites.google.com/view/2018eutypesschool/home">2018,
+August 8-12th, Ohrid, Macedonia, EUTypes Summer School on Types for
+Programming and Verification</a></li>
+<li><a href="https://github.com/math-comp/math-comp/wiki/tutorial-itp2016">2016,
+August 27th, Nancy, France, Math-Comp tutorial at ITP</a></li>
+<li><a href="http://www.cis.upenn.edu/~rrand/popl_2016/">2016, January
+18th, St Petersburg, FA, USA, Coq tutorial at POPL</a></li>
+<li><a href="http://www.strub.nu/coq-itp-15/">2015, August 27th,
+Nanjing, China, Coq tutorial at ITP</a></li>
+<li><a href="http://yann.regis-gianas.org/coqepit/index.fr.html">2015,
+May 25-29th, Fréjus, France, EPIT (TCS Spring School)</a></li>
+<li><a href="http://pauillac.inria.fr/~levy/courses/tsinghua/13coq/">2013,
+August 5-10th, Beijing, Asian-Pacific Summer School on Formal
+Methods</a></li>
+<li><a href="http://videos.rennes.inria.fr/Conference-ITP/indexAssiaMahboubiEnricoTassi.html">2013,
+July 24th, Rennes, France, Math-Comp tutorial at ITP</a></li>
+<li><a href="http://www-sop.inria.fr/manifestations/MapSpringSchool/">2012,
+March 12-16th, Sophia-Antipolis, France, International Spring School
+on Formalization of Mathematics</a></li>
+<li><a href="https://coq.inria.fr/news/3rd-asian-pacific-summer-school-on-formal-methods.html">2011,
+August 13-21st, Suzhou, China, Asian-Pacific Summer School on Formal
+Methods</a></li>
+<li><a href="https://www.di.ens.fr/~zappa/teaching/coq/ecole10/">2010,
+June 7-11th, Paris, France, CEA-EDF-INRIA summer school</a></li>
+
+<#include "incl/footer.html">


### PR DESCRIPTION
In particular, mention the Math-Comp Winter School and the UniMath schools which were not listed there yet. Are there other recurring schools that I don't know about?

We could also mention non-recurring events, such as:
- http://www.strub.nu/coq-itp-15/
- http://www.cis.upenn.edu/~rrand/popl_2016/
- etc.

In any case, the goal of this PR, and the previous one (#92) is clearly to give more visibility to Coq events and to show to the public that we are a very active community, but also to encourage anyone organizing an event to open a PR and add it to the list.