### PR TITLE
Typo in the page about creating coq opam packages

### DIFF
--- a/pages/opam-packaging.html
+++ b/pages/opam-packaging.html
@@ -73,7 +73,7 @@ called <code>upstream</code>, and one for your fork, called <code>origin</code>.
 
 <pre><code>git clone https://github.com/coq/opam-coq-archive -o upstream
 cd opam-coq-archive
-git add origin https://github.com/$YOU/opam-coq-archive
+git remote add origin https://github.com/$YOU/opam-coq-archive
 </code></pre>
 
 <h3 id="fetch-upstream">Update the repository</h3>


### PR DESCRIPTION
Isn't there a typo in this command line?