### PR TITLE
Privilege installing Coq via opam

### DIFF
--- a/pages/download.html
+++ b/pages/download.html
@@ -27,8 +27,15 @@
 <div class="frameworkcontent">
 
 <p>
-The Coq wiki contains three helpful pages detailing various ways of
-installing Coq for the three most standard operating systems:
+The Coq website contains a page with instructions on
+<a href="/opam-using.html">how to install Coq and related packages via opam</a>.
+This is the recommended method of installation as opam can then be used to install third-party Coq libraries maintained by the community.
+Note however that installing and using opam on Windows requires the use of a Linux compatibility layer such as WSL or MINGW.
+</p>
+  
+<p>
+Additionally, the Coq wiki contains three helpful pages detailing various ways of
+installing Coq for the three most common operating systems:
 </p>
 
 <ul>
@@ -36,11 +43,6 @@ installing Coq for the three most standard operating systems:
 <li><a href="https://github.com/coq/coq/wiki/Installation%20of%20Coq%20on%20Windows">Windows</a>
 <li><a href="https://github.com/coq/coq/wiki/Installation%20of%20Coq%20on%20Mac">MacOS</a>
 </ul>
-
-<p>
-The Coq website also contains a page with instructions on
-<a href="/opam-using.html">how to install Coq and related packages via opam</a>.
-</p>
 
 </div>
 <div class="frameworklinks">


### PR DESCRIPTION
Installing Coq via opam gives access to community packages, which I imagine would be a common ask. I was surprised when I needed to reinstall Coq because the version I installed using apt wasn't recognized by opam as fulfilling the dependency on coq.

I'm not wed to the specific wording here.