### PR TITLE
No news (use Twitter instead), no version (direct to the platform).

### DIFF
--- a/incl/footer.html
+++ b/incl/footer.html
@@ -9,26 +9,8 @@ Still opened: html body div.container div#content div.node div.content
 <div id="sidebar-wrapper">
   <div id="sidebar">
     <div id="block-aggregator-feed-1" class="clear-block block block-aggregator">
-      <h2 class="title">Recent news</h2>
-      <div class="content">
-        <div class="item-list">
-          <ul>
-<#include "incl/news/recent.html">
-          </ul>
-        </div>
-        <div class="more-link">
-          <a href="/news">more</a>
-        </div>
-      </div>
-    </div>
-    <div id="block-block-3" class="clear-block block block-block">
-      <div class="content">
-        <a href="/rss.xml">
-          <img src="/files/feed.png" alt="Syndicate content"
-          title="Syndicate content" width="16" height="16"
-          style="position:relative; top:5px" />&nbsp; Syndicate
-        </a>
-      </div>
+      <a class="twitter-timeline" data-width="350" data-height="700" href="https://twitter.com/CoqLang?ref_src=twsrc%5Etfw">Tweets by CoqLang</a>
+      <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script> 
     </div>
   </div><!-- /sidebar -->
 </div><!-- /sidebar-wrapper -->

--- a/pages/index.html
+++ b/pages/index.html
@@ -30,29 +30,25 @@
 <div class="framework">
 <div class="frameworklabel"><a style="color:black;font-weight:bold" href="/download">How to get it?</a></div>
 <div class="frameworkcontent">
-  <p>You can download <a href="<#CURRENTVERSIONURL>">the current stable version,
-      Coq <#CURRENTVERSION></a>, released in <#CURRENTVERSIONDATE>.</p>
-<#ifdef UPCOMINGVERSION>
-  <p><a href="<#UPCOMINGVERSIONURL>">The upcoming version, Coq <#UPCOMINGVERSION></a>
-    is also available for testing.</p>
-</#ifdef>
+<p>The standard way to install Coq is through
+the <a href="https://github.com/coq/platform/blob/master/README.md">Coq
+platform</a>.
 <p>
 To use Coq, you will need a user interface.  Many editor support
 extensions are available (for Emacs, Vim, VSCode, etc.), as well as
 CoqIDE, a standalone IDE for Coq.
 The <a href="user-interfaces.html">User interfaces</a> page provides a
-full list, with more details.  If you are only looking for a quick way
-to try Coq without installing anything, we recommend you
+full list, with more details.
+
+<p>If you only want a quick way to try Coq without installing
+anything, we recommend you
 use <a href="https://jscoq.github.io">jsCoq</a>.
 </p>
 </div>
 <div class="frameworklinks">
 <ul>
-<li><a href="<#CURRENTVERSIONURL>">Get Coq <#CURRENTVERSION></a></li>
-<#ifdef UPCOMINGVERSION>
-<li><a href="<#UPCOMINGVERSIONURL>">Get Coq <#UPCOMINGVERSION> (testing)</a></li>
-</#ifdef>
-<li><a href="https://jscoq.github.io">Try jsCoq</a></li>
+<li><a href="https://jscoq.github.io">Try with jsCoq</a></li>
+<li><a href="https://github.com/coq/platform/blob/master/README.md">Install the Coq platform</a></li>
 <li><a href="user-interfaces.html">User interfaces</a></li>
 </ul>
 </div>


### PR DESCRIPTION
Since with [CEP#52](https://github.com/coq/ceps/pull/52) the plan is to stop advertising Coq releases directly to users but to direct them to the Coq platform instead (whose releases will be widely announced), this is a (very sketchy) proposal to remove any website update task for the release managers of Coq.

Here's a screenshot:

![2020-12-30-184554_994x847_scrot](https://user-images.githubusercontent.com/1108325/103371307-68b04400-4acf-11eb-89ea-4cbf938be46b.png)