### PR TITLE
Website simplification and Coq platform update.

### DIFF
--- a/incl/macros.html
+++ b/incl/macros.html
@@ -1,9 +1,3 @@
-<#def RELEASES>https://github.com/coq/coq/releases</#def>
-<#def BASEURL>https://github.com/coq/coq/releases/tag/</#def>
-
-<#def CURRENTMAJORVERSION>8.13</#def>
 <#def CURRENTVERSION>8.13.1</#def>
-<#def CURRENTVERSIONDATE>February 2021</#def>
-<#def CURRENTVERSIONTAG>V8.13.1</#def>
-<#def CURRENTVERSIONURL><#BASEURL><#CURRENTVERSIONTAG></#def>
+<#def CURRENTVERSIONTAG>V<#CURRENTVERSION></#def>
 <#def CURRENTCREDITSURL>https://github.com/coq/coq/blob/<#CURRENTVERSIONTAG>/CREDITS</#def>

--- a/pages/about-coq.html
+++ b/pages/about-coq.html
@@ -12,7 +12,7 @@
       <li>to state mathematical theorems and software specifications;</li>
       <li>to interactively develop formal proofs of these theorems;</li>
       <li>to machine-check these proofs by a relatively small certification "kernel";</li>
-      <li>to extract certified programs to languages like Objective Caml, Haskell or Scheme.</li>
+      <li>to extract certified programs to languages like OCaml, Haskell or Scheme.</li>
     </ul>
 
    <p>As a proof development system, Coq provides interactive proof
@@ -63,14 +63,14 @@
 <div class="frameworklabel">Credits</div>
 <div class="frameworkcontent">
 
-    <p>Coq is the result of about 30 years of research. It started in
+    <p>Coq is the result of more than 30 years of research. It started in
     1984 from an implementation of the Calculus of Constructions at
     INRIA-Rocquencourt by Thierry Coquand and Gérard Huet. In 1991,
     Christine Paulin extended it to the Calculus of Inductive
     Constructions.
 
-    All in all, more than a hundred people contributed to the
-    development of Coq features (see
+    All in all, more than 200 people have contributed to the
+    development of Coq (see
     our <a href="<#CURRENTCREDITSURL>">credits</a> file,
     the <a href="/refman/history.html">history</a>
     and <a href="/refman/changes.html">recent changes</a> chapters in
@@ -78,13 +78,11 @@
     synthetic <a href="/who-did-what-in-coq">who did what</a>
     table).</p>
 
-    <p>The development is coordinated by the ADT Coq (Action for Technological Development), that gathers the teams involved in the implementation of the Coq Proof Assistant. The teams registered in the ADT are the <a href="http://www.inria.fr">INRIA</a> projects <a href="http://www.pps.univ-paris-diderot.fr/pi.r2/">πr²</a> and <a href="http://www-sop.inria.fr/marelle/">Marelle</a>, and the team <a href="http://cedric.cnam.fr/AfficheEquipe.php?id=7&amp;lang=fr">CPR</a> from <a href="http://www.cnam.fr">CNAM</a>.
-</p>
-
-
-    <p> Coq is written in the <a href="https://ocaml.org/index.fr.html">OCaml</a> language, with a bit of C. It is
-    distributed under the <a href="http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html">GNU Lesser General Public Licence Version
-    2.1</a> (LGPL).</p>
+    <p> Coq is written
+    in <a href="https://ocaml.org/index.fr.html">OCaml</a>. It is
+    distributed under
+    the <a href="http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html">GNU
+    Lesser General Public Licence Version 2.1</a> (LGPL).</p>
 </div>
 </div>
 

--- a/pages/documentation.html
+++ b/pages/documentation.html
@@ -12,7 +12,11 @@ documents:</p>
 <ul>
 
 <li>the <a href="/distrib/current/refman/">Reference Manual</a>, which
-is the complete, authoritative source of documentation for Coq;</li>
+is the authoritative source of documentation for Coq.  It
+contains
+a <a href="/distrib/current/refman/changes.html">changelog</a>
+describing updates to Coq,
+which we recommend you read when you upgrade Coq;</li>
 
 <li>the documentation of
 the <a href="/distrib/current/stdlib/">Standard Library</a> distributed
@@ -21,7 +25,8 @@ with the system.</li>
 </ul>
 
 <p>A PDF version of the reference manual can be downloaded from the
-the <a href="<#CURRENTVERSIONURL>">release page</a>.</p>
+the <a href="https://github.com/coq/coq/releases/latest">release
+page</a>.</p>
 
 <p>Note that this reference documentation is not the recommended way to start
 using Coq. See below for more appropriate documentation for beginners.</p>
@@ -32,6 +37,7 @@ using Coq. See below for more appropriate documentation for beginners.</p>
   <ul>
     <li><a href="/distrib/current/refman/">Reference Manual</a></li>
     <li><a href="/distrib/current/stdlib/">Standard Library</a></li>
+    <li><a href="/distrib/current/refman/changes.html">Changelog</a></li>
   </ul>
 </div>
 
@@ -119,7 +125,7 @@ library.</li>
 <div class="frameworkcontent">
 
 <p>The following provide shorter introductions to Coq or specific
-topics, and may be targetted to beginners or more advanced users:</p>
+topics, and may be targeted to beginners or more advanced users:</p>
 
 <ul>
 
@@ -174,7 +180,7 @@ tactics (Gérard Huet, Gilles Kahn and Christine Paulin-Mohring).
 <div class="frameworklabel">Other documentation</div>
 
 <div class="frameworkcontent">
-<p>Some additional ressources:</p>
+<p>Some additional resources:</p>
 
 <ul>
     

--- a/pages/download.html
+++ b/pages/download.html
@@ -1,54 +1,68 @@
 <#include "incl/macros.html">
-<#def TITLE>Coq <#CURRENTVERSION></#def>
+<#def TITLE>Install Coq</#def>
 <#include "incl/header.html">
 
 <div class="framework">
-<div class="frameworklabel">The current version: Coq <#CURRENTVERSION>
+<div class="frameworklabel">The Coq platform
 </div>
 <div class="frameworkcontent">
 
-<p>For downloads (in particular to get installers for Windows and Mac OS, the PDF
-  manual, or a tarball of the sources), please go to
-  <a href="<#CURRENTVERSIONURL>">the release page on GitHub</a>.</p>
+<p>Coq has a rich ecosystem of external packages (libraries and
+plugins) that extend it and make it more powerful.
+The <a href="https://github.com/coq/platform">Coq platform</a>
+provides an easy way to install Coq and a consistent set of packages
+on Windows, macOS and many Linux distributions.</p>
+
+<p>Beginners are encouraged to use one of the binary installers: we
+provide <a href="https://github.com/coq/coq/releases/latest">binary
+installers</a> for Windows and
+a <a href="https://snapcraft.io/coq-prover">Snap package</a>
+compatible with many Linux distributions. A macOS installer for the
+platform is in the works. In the meantime, a macOS installer for just
+Coq + CoqIDE is provided.</p>
+
+<p>Experienced users are advised to run the scripts provided by
+the <a href="https://github.com/coq/platform">Coq platform</a> to
+install from sources as this will allow them to add additional
+packages by <a href="/opam-using.html">using opam</a>.</p>
 
 </div>
 <div class="frameworklinks">
 <ul>
-<li><a href="<#CURRENTVERSIONURL>">Stable release (<#CURRENTVERSION>)</a></li>
-<#ifdef UPCOMINGVERSION>
-<li><a href="<#UPCOMINGVERSIONURL>">Testing release (<#UPCOMINGVERSION>)</a></li>
-</#ifdef>
+<li><a href="https://github.com/coq/coq/releases/latest">Binary installers (Windows and macOS)</a></li>
+<li><a href="https://snapcraft.io/coq-prover">Snap package</a></li>
+<li><a href="https://github.com/coq/platform">Platform scripts</a>
 </ul>
 </div>
 </div>
+
 
 <div class="framework">
-<div class="frameworklabel">How to install Coq on various systems</div>
+<div class="frameworklabel">Other installation methods
+</div>
 <div class="frameworkcontent">
 
-<p>
-The Coq wiki contains three helpful pages detailing various ways of
-installing Coq for the three most standard operating systems:
-</p>
+<p>Coq is available
+through <a href="https://repology.org/metapackage/coq/versions">many
+package managers</a>, including most Linux distribution package
+managers.  However, in many cases, the available version is not
+the latest version.  More importantly, these distributions might
+provide only a fraction of all the external packages available for
+Coq, thus requiring some manual compilation and installation to add
+additional packages.</p>
 
-<ul>
-<li><a href="https://github.com/coq/coq/wiki/Installation%20of%20Coq%20on%20Linux">Linux</a>
-<li><a href="https://github.com/coq/coq/wiki/Installation%20of%20Coq%20on%20Windows">Windows</a>
-<li><a href="https://github.com/coq/coq/wiki/Installation%20of%20Coq%20on%20Mac">MacOS</a>
-</ul>
+<p>Advanced users who want to install Coq and extend it with external
+packages can rely on <a href="/opam-using.html">opam</a>
+or <a href="https://nixos.org/manual/nixpkgs/unstable/#sec-language-coq">Nix</a>.</p>
 
-<p>
-The Coq website also contains a page with instructions on
-<a href="/opam-using.html">how to install Coq and related packages via opam</a>.
-</p>
+<p>Coq is also available as a <a href="https://hub.docker.com/r/coqorg/coq/">Docker image</a>.</p>
 
 </div>
 <div class="frameworklinks">
 <ul>
-<li><a class="extlink" href="https://github.com/coq/coq/wiki/Installation%20of%20Coq%20on%20Linux">Linux</a></li>
-<li><a class="extlink" href="https://github.com/coq/coq/wiki/Installation%20of%20Coq%20on%20Windows">Windows</a></li>
-<li><a class="extlink" href="https://github.com/coq/coq/wiki/Installation%20of%20Coq%20on%20Mac">MacOS</a></li>
-<li><a href="/opam-using.html">opam</a></li>
+<li><a href="/opam-using.html">Using opam</a></li>
+<li><a href="https://nixos.org/manual/nixpkgs/unstable/#sec-language-coq">Nixpkgs manual section on Coq</a></li>
+<li><a href="https://hub.docker.com/r/coqorg/coq/">Docker images</a></li>
 </ul>
 </div>
 </div>
@@ -57,20 +71,24 @@ The Coq website also contains a page with instructions on
 <div class="frameworklabel">Previous and development versions of Coq </div>
 <div class="frameworkcontent">
 
-<p>The development version of Coq is <a href="https://github.com/coq/coq">browsable</a>
-and downloadable from our Git repository using command:
-<tt>git clone https://github.com/coq/coq.git</tt>.
+<p>The development version of Coq and its development history can be
+browsed in its <a href="https://github.com/coq/coq">GitHub
+repository</a>.
 </p>
 
-<p>Most of the previous versions of Coq are available <a href="<#RELEASES>">on
-GitHub</a> or <a href="/distrib/">here</a>.</p>
+<p>When you upgrade your version of Coq, be sure to read
+the <a href="/distrib/current/refman/changes.html">changelog</a>.
+
+<p>Most previous versions of Coq are
+available <a href="https://github.com/coq/coq/releases">on GitHub</a>
+or <a href="/distrib/">here</a>.</p>
 
 </div>
 <div class="frameworklinks">
 <ul>
 <li><a class="extlink" href="https://github.com/coq/coq">GitHub repository</a></li>
-<li><a class="extlink" href="<#RELEASES>">All GitHub releases</a></li>
-<li><a href="/distrib/">Old releases</a></li>
+<li><a class="extlink" href="https://github.com/coq/coq/releases">All GitHub releases</a></li>
+<li><a href="/distrib/">Very old releases</a></li>
 </ul>
 </div>
 </div>

--- a/pages/index.html
+++ b/pages/index.html
@@ -4,7 +4,7 @@
 <#include "incl/header.html">
 
 <div class="framework">
-<div class="frameworklabel"><a style="color:black;font-weight:bold" href="/about-coq">What is Coq?</a></div>
+<div class="frameworklabel"><a  style="color:black;font-weight:bold" href="/documentation">Learning about Coq</a></div>
 <div class="frameworkcontent">
   <p>Coq is a formal proof management system.
   It provides a formal language to write mathematical definitions, executable algorithms and theorems together with an environment for semi-interactive development of machine-checked proofs.
@@ -17,100 +17,56 @@
   or <a href="http://homotopytypetheory.org/coq/">homotopy type theory</a>),
   and <a href="/cocorico/CoqInTheClassroom">teaching</a>.
   </p>
+
+  <p>The <a
+  href="/distrib/current/refman/">Reference Manual</a> and the
+  <a href="/distrib/current/stdlib/">Standard Library
+  documentation</a> are the primary documentation for Coq.  However,
+  to learn about Coq, we recommend starting with a tutorial or book,
+  such as those listed on the <a href="/documentation">documentation
+  page</a>.
+  </p>
+
 </div>
 
 <div class="frameworklinks">
 <ul>
-<li><a href="/about-coq"> More about Coq </a></li>
+<li><a href="/documentation">Tutorials and books</a></li>
+<li><a href="/distrib/current/refman/"> Reference Manual </a></li>
+<li><a href="/distrib/current/stdlib/"> Standard Library </a></li>
 </ul>
 </div>
 </div>
 
-
 <div class="framework">
-<div class="frameworklabel"><a style="color:black;font-weight:bold" href="/download">How to get it?</a></div>
+<div class="frameworklabel"><a style="color:black;font-weight:bold" href="/download">Running Coq</a></div>
 <div class="frameworkcontent">
-  <p>You can download <a href="<#CURRENTVERSIONURL>">the current stable version,
-      Coq <#CURRENTVERSION></a>, released in <#CURRENTVERSIONDATE>.</p>
-<#ifdef UPCOMINGVERSION>
-  <p><a href="<#UPCOMINGVERSIONURL>">The upcoming version, Coq <#UPCOMINGVERSION></a>
-    is also available for testing.</p>
-</#ifdef>
-<p>
-To use Coq, you will need a user interface.  Many editor support
-extensions are available (for Emacs, Vim, VSCode, etc.), as well as
-CoqIDE, a standalone IDE for Coq.
-The <a href="user-interfaces.html">User interfaces</a> page provides a
-full list, with more details.  If you are only looking for a quick way
-to try Coq without installing anything, we recommend you
-use <a href="https://jscoq.github.io">jsCoq</a>.
+<p>You don't need to install Coq to get started: you can run Coq in your browser using
+<a href="https://jscoq.github.io">jsCoq</a>!</p>
+
+<p>Eventually you'll probably want to <a href="/download">install the Coq platform</a>
+on your system with a <a href="user-interfaces.html">user interface</a> of your choice.
 </p>
 </div>
 <div class="frameworklinks">
 <ul>
-<li><a href="<#CURRENTVERSIONURL>">Get Coq <#CURRENTVERSION></a></li>
-<#ifdef UPCOMINGVERSION>
-<li><a href="<#UPCOMINGVERSIONURL>">Get Coq <#UPCOMINGVERSION> (testing)</a></li>
-</#ifdef>
-<li><a href="https://jscoq.github.io">Try jsCoq</a></li>
+<li><a href="https://jscoq.github.io">Try Coq in your browser</a></li>
+<li><a href="/download">Install the Coq platform</a></li>
 <li><a href="user-interfaces.html">User interfaces</a></li>
 </ul>
 </div>
 </div>
 
 <div class="framework">
-<div class="frameworklabel"><a  style="color:black;font-weight:bold" href="https://github.com/coq/coq/blob/master/CONTRIBUTING.md">How to contribute?</a></div>
-<div class="frameworkcontent">
-    <p>You can contribute to the development of Coq by reporting bugs,
-    submitting pull requests, improving the documentation, and in many other
-    ways. We are also looking for sponsors who want to contribute financially
-    through the <a href="/consortium">Coq Consortium</a>. If you are interested,
-    please get in touch!</p>
-</div>
-
-<div class="frameworklinks">
-<ul>
-<li><a href="/bugs/">Bug tracker</a></li>
-<li><a href="https://github.com/coq/coq/blob/master/CONTRIBUTING.md">Contributing guide</a></li>
-<li><a href="/consortium">Coq Consortium</a></li>
-</ul>
-</div>
-</div>
-
-<div class="framework">
-<div class="frameworklabel"><a  style="color:black;font-weight:bold" href="/documentation">Documentation</a></div>
-<div class="frameworkcontent">
-  <p>The reference documentation for Coq are the <a
-  href="/distrib/current/refman/"> Reference Manual </a> and the
-  documentation of the <a href="/distrib/current/stdlib/">
-  Standard Library</a>. Other useful documents
-  (tutorials, faq, ...) are available from the <a
-  href="/documentation">documentation</a>
-  page.</p>
-</div>
-
-<div class="frameworklinks">
-<ul>
-<li><a href="/distrib/current/refman/"> Reference Manual </a></li>
-<li><a href="/distrib/current/stdlib/"> Standard Library </a></li>
-<li><a href="/documentation">All Documents</a></li>
-</ul>
-</div>
-</div>
-
-
-<div class="framework">
-<div class="frameworklabel"><a style="color:black;font-weight:bold" href="/community.html">The Coq Community</a></div>
+<div class="frameworklabel"><a style="color:black;font-weight:bold" href="/community.html">User Community</a></div>
 <div class="frameworkcontent">
 
-<p>There is a strong and active community of users working with
-Coq. They are contributing formal developments,
-extensions of Coq
-(see <a href="/packages.html">Coq Package Index</a>),
-and tools based on Coq
-(see <a href="/related-tools.html">Related Tools</a>).
-We have a (multi-lingual) <a href="https://coq.discourse.group">Discourse forum</a>
-and a <a href="https://coq.zulipchat.com">Zulip chat</a>.
+<p>Coq has a large and active user community. They contribute
+formal developments, Coq extensions
+(see <a href="/packages.html">Coq Package Index</a>) and tools based
+on Coq (see <a href="/related-tools.html">Related Tools</a>).  We have
+a multi-lingual <a href="https://coq.discourse.group">Discourse
+forum</a> and a <a href="https://coq.zulipchat.com">Zulip chat</a>.
 </p>
 
 </div>
@@ -124,5 +80,26 @@ and a <a href="https://coq.zulipchat.com">Zulip chat</a>.
 </ul>
 </div>
 </div><!-- /framework -->
+
+<div class="framework">
+<div class="frameworklabel"><a style="color:black;font-weight:bold" href="https://github.com/coq/coq/blob/master/CONTRIBUTING.md">Contributing to Coq</a></div>
+<div class="frameworkcontent">
+    <p>You can contribute to the development of Coq by reporting bugs,
+    suggesting enhancements,
+    submitting pull requests, improving the documentation and in many other
+    ways. We are also looking for sponsors who want to support the development
+    of Coq financially
+    through the <a href="/consortium">Coq Consortium</a>. If you are interested,
+    please get in touch!</p>
+</div>
+
+<div class="frameworklinks">
+<ul>
+<li><a href="/bugs/">Bug tracker</a></li>
+<li><a href="https://github.com/coq/coq/blob/master/CONTRIBUTING.md">Contributing guide</a></li>
+<li><a href="/consortium">Coq Consortium</a></li>
+</ul>
+</div>
+</div>
 
 <#include "incl/footer.html">

--- a/pages/opam-using.html
+++ b/pages/opam-using.html
@@ -19,6 +19,23 @@ opam --version
 <p>Follow the instructions below to install the last stable version of Coq and
 additional packages. The instructions target an opam newcomer.</p>
 
+<h2 id="platform">The Coq platform scripts</h2>
+
+<p>The <a href="https://github.com/coq/platform">Coq platform</a>
+provides interactive scripts that allow installing Coq and a standard
+set of packages through opam without having to learn anything about
+opam.  We recommend that you use
+these <a href="https://github.com/coq/platform">scripts</a>.  If you
+do, you can skip directly to <a href="#coq-packages">Using opam to
+install Coq packages</a> to learn how to add additional packages to
+the initial package set provided by the platform.</p>
+
+<p>Note that the platform scripts are compatible with existing opam
+installations. They will create a fresh <a href="#switch">switch.</a></p>
+
+<p>If you prefer to do a fully manual installation, you can proceed to
+the next section.</p>
+
 <h2>Initializing opam</h2>
 
 <p>Once opam is installed, it must be initialized before first usage:</p>
@@ -91,11 +108,12 @@ built and installed with the following command:</p>
 interfaces / editor extensions</a> for Coq.  See their respective
 websites for instructions on how to install them.</p>
 
-<h2>Using opam to install Coq packages</h2>
+<h2 id="coq-packages">Using opam to install Coq packages</h2>
 
-<p>Coq packages live in a repository separate from the standard OCaml opam
-repository. The following command adds that repository to the current
-opam switch (more on switches below):</p>
+<p>Coq packages live in a repository separate from the standard OCaml
+opam repository. The following command adds that repository to the
+current opam <a href="#switch">switch</a> (you can skip this step if
+you used the <a href="#platform">platform scripts</a>):</p>
 
 <pre><code>opam repo add coq-released https://coq.inria.fr/opam/released
 </code></pre>
@@ -123,7 +141,7 @@ using the command:</p>
 different versions of OCaml and other packages (including Coq) via
 <em>switches</em> or <em>roots</em>.</p>
 
-<h3>Switches</h3>
+<h3 id="switch">Switches</h3>
 
 <p>Switches provide separate environments, with their own versions of OCaml and
 installed packages.</p>


### PR DESCRIPTION
This is a major update to the website home page and Coq installation pages to put the focus on the Coq platform installation method (cc @gares @MSoegtropIMC). It also reduces the importance of the current version number on the website in relation with [CEP#52](https://github.com/coq/ceps/pull/52) (but we still need it, mostly in the opam using page). For the homepage, I also tried to think at what we would like to put forward if the design of the website was reworked, but without doing any change to the design yet.

The diff for the index page and the download page might be a bit hard to follow, so here are some preview screenshots:

![2021-01-13-195725_613x904_scrot](https://user-images.githubusercontent.com/1108325/104496731-a4700100-55d9-11eb-93e3-dc99ff2f3086.png)
![2021-01-13-195647_617x797_scrot](https://user-images.githubusercontent.com/1108325/104496739-a76af180-55d9-11eb-927c-aa87c7247c27.png)

cc @jfehrle (I cannot request a review from you on this repository)
