### PR TITLE
Archive the news section.

### DIFF
--- a/incl/footer.html
+++ b/incl/footer.html
@@ -11,23 +11,10 @@ Still opened: html body div.container div#content div.node div.content
     <div id="block-aggregator-feed-1" class="clear-block block block-aggregator">
       <h2 class="title">Recent news</h2>
       <div class="content">
-        <div class="item-list">
-          <ul>
-<#include "incl/news/recent.html">
-          </ul>
-        </div>
-        <div class="more-link">
-          <a href="/news">more</a>
-        </div>
-      </div>
-    </div>
-    <div id="block-block-3" class="clear-block block block-block">
-      <div class="content">
-        <a href="/rss.xml">
-          <img src="/files/feed.png" alt="Syndicate content"
-          title="Syndicate content" width="16" height="16"
-          style="position:relative; top:5px" />&nbsp; Syndicate
-        </a>
+        <p>Check
+        out <a href="https://coq.discourse.group/c/announcements/8">Discourse</a>
+        and <a href="https://twitter.com/CoqLang">Twitter</a> for
+        recent news.</p>
       </div>
     </div>
   </div><!-- /sidebar -->

--- a/incl/footer.html
+++ b/incl/footer.html
@@ -15,6 +15,10 @@ Still opened: html body div.container div#content div.node div.content
         out <a href="https://coq.discourse.group/c/announcements/8">Discourse</a>
         and <a href="https://twitter.com/CoqLang">Twitter</a> for
         recent news.</p>
+        <p>For recent releases, check out the GitHub repositories
+        of <a href="https://github.com/coq/coq/releases">Coq</a> and
+        the <a href="https://github.com/coq/platform/releases">Coq
+        platform</a>.</p>
       </div>
     </div>
   </div><!-- /sidebar -->

--- a/incl/header.html
+++ b/incl/header.html
@@ -22,7 +22,7 @@
           <li><a href="/documentation">Documentation</a></li>
           <li><a href="/community">Community</a></li>
           <li><a href="/consortium">Consortium</a></li>
-          <li><a href="/news">News</a></li>
+          <li><a href="/news">Old news</a></li>
         </ul>
       </div><!-- /nav -->
       <a href="https://github.com/coq/coq">

--- a/incl/news/title.html
+++ b/incl/news/title.html
@@ -1,1 +1,1 @@
-<#def TITLE>News</#def>
+<#def TITLE>Old news</#def>


### PR DESCRIPTION
The news section isn't used anymore except to announce new releases. We've recently acted that we wouldn't announce Coq releases anymore, only Coq platform releases. The last Coq platform release was announced on GitHub + Coq-Club + Discourse but not on the website for lack of time. Removing the news section would reduce the work of platform maintainers.

My proposal is a minimal change. I didn't remove the code that was able to generate the last three news items for the side-bar. I didn't remove the side-bar. I'm aware it is far from ideal but I'm also counting on a website redesign in (let's say) less than a year, and trying to focus on the content first.

Main page:
![old-news](https://user-images.githubusercontent.com/1108325/114896880-fe6aa780-9e10-11eb-9134-b3f7d6be0b43.png)

News page:
![old-news-2](https://user-images.githubusercontent.com/1108325/114896982-19d5b280-9e11-11eb-8370-5495304d4450.png)

cc @herbelin who expressed the idea of linking to the pages that are actually used for announcements nowadays
cc @gares who managed or contributed to recent releases of both Coq and the Coq platform