### PR TITLE
Add link to the opam-bench project in the Coq Team

### DIFF
--- a/pages/coq-team.html
+++ b/pages/coq-team.html
@@ -236,7 +236,7 @@
     </div>
     <div class="name"><a href="http://guillaume.claret.me/">Guillaume Claret</a></div><div class="nickname">clarus</div>
     <div class="position">Coq Engineer at Nomadic Labs, Paris, France</div>
-    <div class="components">opam, coq-io</div>
+    <div class="components">Opam, coq-io, <a href="https://coq-bench.github.io/">opam-bench</a></div>
   </div>
   <div class="person">
     <div class="picture">


### PR DESCRIPTION
@mattam82 As you proposed, I added a link to the opam bench. I did not add other links in this pull-request. How it appears with the link:

![image](https://user-images.githubusercontent.com/316665/124176669-7ca12680-daaf-11eb-8714-cb309b509180.png)
