### PR TITLE
fix related-tools redirect mangling of hashtag

### DIFF
--- a/aliases.footer.conf
+++ b/aliases.footer.conf
@@ -10,7 +10,7 @@ RewriteRule ^files/nahas_tutorial.v$ https://mdnahas.github.io/doc/nahas_tutoria
 # opam/www/using.html and co. moved to opam-using early 2019
 RewriteRule ^opam/www/(layout|packaging|using).html$ opam-$1.html [R=301,L]
 # Awesome Coq tools section replaced related-tools page mid 2021
-RewriteRule ^related-tools(|.html|/)$ https://github.com/coq-community/awesome-coq#tools [R=301,L]
+RewriteRule ^related-tools(|.html|/)$ https://github.com/coq-community/awesome-coq#tools [NE,R=301,L]
 # Requests to /static/something are redirected one level up with a 301
 # The REDIRECT_END variable avoids infinite redirect loops
 RewriteCond   %{ENV:REDIRECT_END}  !^1


### PR DESCRIPTION
After #176 was merged, I noticed that the redirect for `related-tools` was not working - it goes to the 404 URL: https://github.com/coq-community/awesome-coq%23tools

The problem is that the hashtag `#` is getting mangled/escaped. Per the [manual for RewriteRule](https://httpd.apache.org/docs/current/rewrite/flags.html#flag_ne), the correct way to fix this is using the option `NE` (NoEscape), which I do in this fix.