### PR TITLE
link updates and uniformization of book list

### DIFF
--- a/pages/documentation.html
+++ b/pages/documentation.html
@@ -52,33 +52,34 @@ Coq users and teachers:</p>
 
 <ul>
 
-<li><a href="http://www.labri.fr/perso/casteran/CoqArt/">Coq'Art</a>,
-the first book dedicated to the Coq proof assistant (Yves Bertot,
-Pierre Castéran, 2004, Chinese version in 2009), only the French
-version and the exercises can be downloaded for free, English version
-is available
-on <a href="https://link.springer.com/book/10.1007/978-3-662-07964-5">Springer's
-website</a>;</li>
+<li><a href="https://www.labri.fr/perso/casteran/CoqArt/">Coq'Art</a>
+(Yves Bertot and Pierre Castéran, 2004, Chinese version in 2009),
+the first book dedicated to the Coq proof assistant, only the French
+version and the
+<a href="https://github.com/coq-community/coq-art">Coq source and
+exercises</a> can be downloaded for free, an English version is available from
+<a href="https://link.springer.com/book/10.1007/978-3-662-07964-5">Springer's
+website</a>.</li>
 
-<li><a href="http://www.cis.upenn.edu/~bcpierce/sf/">Software
-Foundations</a>, a series of Coq-based textbooks on logic, functional
-programming and foundations of programming languages (Benjamin
-Pierce <em>et al</em>, 2007, with regular updates), much acclaimed for
+<li><a href="https://softwarefoundations.cis.upenn.edu">Software
+Foundations</a> (Benjamin Pierce <em>et al.</em>, 2007, with regular updates),
+a series of Coq-based textbooks on logic, functional
+programming and foundations of programming languages , much acclaimed for
 being accessible to beginners, but rather oriented to computer
-scientists;</li>
+scientists.</li>
 
 <li><a href="http://adam.chlipala.net/cpdt/">Certified Programming
-with Dependent Types</a>, a textbook about practical engineering with
-Coq (Adam Chlipala, 2008), teaches advanced practical tricks and a
-very specific style of proof;</li>
+with Dependent Types</a> (Adam Chlipala, 2008), a textbook about
+practical engineering with Coq, teaches advanced practical tricks
+and a very specific style of proof.</li>
 
-<li><a href="https://www.cambridge.org/us/academic/subjects/computer-science/programming-languages-and-applied-logic/program-logics-certified-compilers">Program
-Logics for Certified Compilers</a>, (Andrew W. Appel <em>et al.</em>,
+<li><a href="https://www.cs.princeton.edu/~appel/papers/plcc.pdf">Program
+Logics for Certified Compilers</a> (Andrew W. Appel <em>et al.</em>,
 2014), a book that explains how to construct powerful and expressive
 program logics using the theory of separation logic, accompanied by a
 formal model in Coq,
 the <a href="https://vst.cs.princeton.edu">Verified Software
-Toolchain</a>, which is applied to the C light programming language
+Toolchain</a>, which is applied to the Clight programming language
 and other examples.</li>
 
 <li><a href="http://adam.chlipala.net/frap/">Formal Reasoning About
@@ -86,7 +87,7 @@ Programs</a> (Adam Chlipala, 2017), a book that simultaneously
 provides a general introduction to formal logical reasoning about the
 correctness of programs and to using Coq for this purpose.</li>
 
-<li><a href="https://ilyasergey.net/pnp/">Programs and Proofs</a>,
+<li><a href="https://ilyasergey.net/pnp/">Programs and Proofs</a>
 (Ilya Sergey, 2017), a book that gives a brief and
 practically-oriented introduction to the basic concepts of interactive
 theorem proving using Coq; emphasizes the computational nature of
@@ -94,13 +95,13 @@ inductive reasoning about decidable propositions via a small set of
 primitives from the SSreflect proof language.</li>
 
 <li><a href="http://iste.co.uk/book.php?id=1238">Computer Arithmetic
-and Formal Proofs</a>, (S. Boldo and G. Melquiond, 2017), a book that
+and Formal Proofs</a> (Sylvie Boldo and Guillaume Melquiond, 2017), a book that
 gives a comprehensive view of how to formally specify and verify
 tricky floating-point algorithms with Coq using the
 <a href="https://gitlab.inria.fr/flocq/flocq">Flocq library</a>.</li>
 
-<li>the <a href="https://math-comp.github.io/mcb/">Mathematical
-Components book</a> (A. Mahboubi and E. Tassi, 2018), a book that is
+<li><a href="https://math-comp.github.io/mcb/">Mathematical
+Components</a> (Assia Mahboubi and Enrico Tassi, 2018), a book that is
 more oriented towards mathematically inclined users, to dive into Coq
 with the SSReflect proof language, and the Mathematical Components
 library.</li>
@@ -111,8 +112,8 @@ library.</li>
 
 <div class="frameworklinks">
   <ul>
-    <li><a href="http://www.labri.fr/perso/casteran/CoqArt/">Coq'Art</a></li>
-    <li><a href="http://www.cis.upenn.edu/~bcpierce/sf/">SF</a></li>
+    <li><a href="https://www.labri.fr/perso/casteran/CoqArt/">Coq'Art</a></li>
+    <li><a href="https://softwarefoundations.cis.upenn.edu">SF</a></li>
     <li><a href="http://adam.chlipala.net/cpdt/">CPDT</a></li>
     <li><a href="https://math-comp.github.io/mcb/">MCB</a></li>
   </ul>


### PR DESCRIPTION
The list of "books and long tutorials" has some outdated and missing links and is non-uniform, which I try to address in this PR.

Recently, a draft of a new 350+ page book on Coq appeared (https://github.com/uds-psl/MPCTT), but we should probably check with the author if he wants it listed before adding it, so I didn't include it here.