### PR TITLE
Link to new Proof Assistants SE site.

### DIFF
--- a/pages/community.html
+++ b/pages/community.html
@@ -17,6 +17,10 @@ and high traffic discussions, which are continuously
 <li>Our <a href="https://coq.discourse.group">Discourse forum</a>, for
 more structured and easily browsable discussions and Q&amp;A.  Posts in
 other languages than English are explicitly welcome there.
+<li>The <a href="https://proofassistants.stackexchange.com">Proof
+Assistants Stack Exchange</a> Q&amp;A site. Make sure to use
+the <a href="https://proofassistants.stackexchange.com/questions/tagged/coq">coq</a>
+tag to get your questions noticed by Coq users.
 <li>Our historical mailing list, the
 <a href="https://sympa.inria.fr/sympa/info/coq-club">Coq-Club</a>.
 <li>Our <a href="https://github.com/coq/coq/issues">GitHub issue
@@ -27,13 +31,12 @@ tracker</a>, for bug reports and feature requests.
 The following channels also have a strong presence of Coq users:
 </p>
 <ul>
-<li><a href="https://stackoverflow.com/">Stack Overflow</a> (use the
-<a href="https://stackoverflow.com/questions/tagged/coq">coq</a> tag).
-<li>
-<a href="https://cstheory.stackexchange.com">TCS Stack Exchange</a>
-(which also has
-a <a href="https://cstheory.stackexchange.com/questions/tagged/coq">coq</a>
-tag) for questions on the meta-theory of Coq.
+<li>Other sites in the Stack Exchange galaxy, such
+as <a href="https://stackoverflow.com/">Stack Overflow</a>
+(<a href="https://stackoverflow.com/questions/tagged/coq">coq</a> tag)
+and <a href="https://cstheory.stackexchange.com">TCS Stack Exchange</a>
+(<a href="https://cstheory.stackexchange.com/questions/tagged/coq">coq</a>
+tag) also receive questions about Coq.
 <li><a href="https://www.reddit.com/r/Coq/">/r/Coq</a> on Reddit.
 <li>The <a href="irc://irc.libera.chat:6697/#coq">#coq</a> IRC channel on
 <a href="https://libera.chat/">Libera.Chat</a>.
@@ -52,6 +55,7 @@ from many of the above channels.
 
 <div class="frameworklinks">
 <ul>
+<li><a class="extlink" href="https://proofassistants.stackexchange.com">Proof Assistants SE</a></li>
 <li><a class="extlink" href="https://coq.discourse.group">Discourse forum</a></li>
 <li><a class="extlink" href="https://coq.zulipchat.com">Zulip chat</a></li>
 <li><a class="extlink" href="https://twitter.com/CoqLang">Twitter account</a></li>


### PR DESCRIPTION
Preview:

![image](https://user-images.githubusercontent.com/1108325/158450591-21874283-9423-43c0-ac11-bd1ec307e4b6.png)

Should we also add the link on the homepage?