### PR TITLE
Make it easier to get Coq.

### DIFF
--- a/pages/download.html
+++ b/pages/download.html
@@ -3,7 +3,7 @@
 <#include "incl/header.html">
 
 <div class="framework">
-<div class="frameworklabel">The Coq platform
+<div class="frameworklabel">The Coq platform (recommended)
 </div>
 <div class="frameworkcontent">
 
@@ -13,7 +13,7 @@ The <a href="https://github.com/coq/platform">Coq platform</a>
 provides an easy way to install Coq and a consistent set of packages
 on Windows, macOS and many Linux distributions.</p>
 
-<p>Beginners are encouraged to use one of the binary installers: we
+<p><strong>Beginners are encouraged to use one of the binary installers:</strong> we
 provide <a href="https://github.com/coq/platform/releases/latest">binary
 installers for Windows and macOS</a> and
 a <a href="https://snapcraft.io/coq-prover">Snap package</a>

--- a/pages/index.html
+++ b/pages/index.html
@@ -44,14 +44,14 @@
 <p>You don't need to install Coq to get started: you can run Coq in your browser using
 <a href="https://jscoq.github.io">jsCoq</a>!</p>
 
-<p>Eventually you'll probably want to <a href="/download">install the Coq platform</a>
+<p>Eventually you'll probably want to <a href="/download">install Coq</a>
 on your system with a <a href="user-interfaces.html">user interface</a> of your choice.
 </p>
 </div>
 <div class="frameworklinks">
 <ul>
 <li><a href="https://jscoq.github.io">Try Coq in your browser</a></li>
-<li><a href="/download">Install the Coq platform</a></li>
+<li><a href="/download">Install Coq on your computer</a></li>
 <li><a href="user-interfaces.html">User interfaces</a></li>
 </ul>
 </div>


### PR DESCRIPTION
Following a point made by Pierre Rousselin on the private mailing list gt-maths-coq, this PR makes two small modifications to the website to make it clearer how to get Coq.

1. Do not mention the "Platform" on the homepage because prospective users do not know yet what it is and there is no space to explain.
2. On the download page, clarify what is the recommended installation method for beginners, including for those who do not want to read the page closely.
3. This is outside the scope of this PR: the third change should be in the formatting of the Coq Platform releases (cc @MSoegtropIMC). We should insert three prominent links at the top of the GitHub releases pointing to the Windows (64 bit) installer, the macOS installer, and the Snap package. Something like:

   ```markdown
   ### Recommended binary installers

   - [Windows (64 bit) installer for Coq 8.15](https://github.com/coq/platform/releases/download/2022.04.1/Coq-Platform-release-2022.04.1-version_8.15_2022.04-arch-x86_64_signed.exe)
   - [macOS installer for Coq 8.15](https://github.com/coq/platform/releases/download/2022.04.1/Coq-Platform-release-2022.04.1-version.8.15.2022.04-signed.dmg)
   - [Linux (Snap) installer for Coq 8.15](https://snapcraft.io/coq-prover)
   ```

   Currently, there is a lot of text and the installers are at the bottom, and even then, there are too many of them, thus it is too difficult for a prospective user to know what to install.

## Screenshots

### Homepage

![image](https://user-images.githubusercontent.com/1108325/191467963-6c231f7e-fb3d-4207-8a43-145b245bc70d.png)

### Download page

![image](https://user-images.githubusercontent.com/1108325/191467856-a9f7508f-0326-4483-816d-8a19b1b1964e.png)
