### PR TITLE
consistently capitalize Platform when referring to Coq Platform

### DIFF
--- a/incl/footer.html
+++ b/incl/footer.html
@@ -22,7 +22,7 @@ Still opened: html body div.container div#content div.node div.content
         <p>For recent releases, check out the GitHub repositories
         of <a href="https://github.com/coq/coq/releases">Coq</a> and
         the <a href="https://github.com/coq/platform/releases">Coq
-        platform</a>.</p>
+        Platform</a>.</p>
       </div>
     </div>
   </div><!-- /sidebar -->

--- a/pages/download.html
+++ b/pages/download.html
@@ -3,13 +3,13 @@
 <#include "incl/header.html">
 
 <div class="framework">
-<div class="frameworklabel">The Coq platform (recommended)
+<div class="frameworklabel">The Coq Platform (recommended)
 </div>
 <div class="frameworkcontent">
 
 <p>Coq has a rich ecosystem of external packages (libraries and
 plugins) that extend it and make it more powerful.
-The <a href="https://github.com/coq/platform">Coq platform</a>
+The <a href="https://github.com/coq/platform">Coq Platform</a>
 provides an easy way to install Coq and a consistent set of packages
 on Windows, macOS and many Linux distributions.</p>
 
@@ -19,10 +19,11 @@ installers for Windows and macOS</a> and
 a <a href="https://snapcraft.io/coq-prover">Snap package</a>
 compatible with many Linux distributions.</p>
 
-<p>Experienced users are advised to run the scripts provided by
-the <a href="https://github.com/coq/platform">Coq platform</a> to
-install from sources as this will allow them to install additional
-packages with <a href="/opam-using.html">opam</a>.</p>
+<p>Experienced users are advised to run the
+<a href="https://github.com/coq/platform/releases/latest">
+Coq Platform scripts</a> to install from sources,
+as this will allow them to install additional packages with
+<a href="/opam-using.html">opam</a>.</p>
 
 </div>
 <div class="frameworklinks">

--- a/pages/opam-using.html
+++ b/pages/opam-using.html
@@ -33,20 +33,20 @@ please consult
 the <a href="https://github.com/coq/coq/blob/master/INSTALL.md">INSTALL.md
 documentation in the GitHub repository</a>.</p>
 
-<h2 id="platform">The Coq platform scripts</h2>
+<h2 id="platform">The Coq Platform scripts</h2>
 
-<p>The <a href="https://github.com/coq/platform">Coq platform</a>
+<p>The <a href="https://github.com/coq/platform">Coq Platform</a>
 provides interactive scripts that allow installing Coq and a standard
 set of packages through opam without having to learn anything about
 opam.</p>
 
 <p>If a standard setup works for you, then we recommend that you use
-these <a href="https://github.com/coq/platform">scripts</a>.  If you
-do, you can skip directly to <a href="#coq-packages">Using opam to
+these <a href="https://github.com/coq/platform/releases/latest">scripts</a>.
+If you do, you can skip directly to <a href="#coq-packages">Using opam to
 install Coq packages</a> to learn how to add additional packages to
-the initial package set provided by the platform.</p>
+the initial package set provided by the Platform.</p>
 
-<p>Note that the platform scripts are compatible with existing opam
+<p>Note that the Platform scripts are compatible with existing opam
 installations. They will create a
 fresh <a href="#switch">switch.</a></p>
 
@@ -115,7 +115,7 @@ websites for instructions on how to install them.</p>
 <p>Coq packages live in a repository separate from the standard OCaml
 opam repository. The following command adds that repository to the
 current opam <a href="#switch">switch</a> (you can skip this step if
-you used the <a href="#platform">platform scripts</a>):</p>
+you used the <a href="#platform">Platform scripts</a>):</p>
 
 <pre><code>opam repo add coq-released https://coq.inria.fr/opam/released
 </code></pre>


### PR DESCRIPTION
Note that Coq as a "platform" is sometimes used in a more general sense, so we'd like to avoid confusion. Also, consistently link to latest Platform release for the scripts. 