### PR TITLE
mention about Coq Platform over installers in general context

### DIFF
--- a/pages/community.html
+++ b/pages/community.html
@@ -72,8 +72,8 @@ The Coq user community has contributed a large ecosystem of
 formalization works and plugins throughout the years. An index of
 packages can be <a href="/opam/www">browsed online</a>. Installing
 them can be done using the <a href="/opam-using.html">opam</a> package
-manager. Some of these packages are also bundled in the Windows
-installer.</p>
+manager. A subset of these packages are also included in the
+<a href="https://github.com/coq/platform">Coq Platform</a>.</p>
 
 <p>Users are encouraged to <a href="/opam-packaging.html">submit their
 packages to the index</a>. They are also encouraged


### PR DESCRIPTION
A remnant from when the Windows installer was the main curated distribution.