### PR TITLE
Upgrade Pierre Roux and fix various bugs in the team page

### DIFF
--- a/pages/coq-team.html
+++ b/pages/coq-team.html
@@ -156,7 +156,7 @@
     <div class="nickname">maximedenes</div>
     <div class="position">Inria Engineer in the Coq Consortium, attached to the Stamp Team, Sophia-Antipolis, France</div>
     <div class="role">RM: 8.5, 8.6, 8.7, 8.8, 8.13</div>
-    <div class="components">General Maintenance, CI, <verb>native_compute</verb>, Kernel, Unification, VSCoq</div>
+    <div class="components">General Maintenance, CI, <code>native_compute</code>, Kernel, Unification, VSCoq</div>
   </div>  
   <div class="person">
     <div class="picture"><img src="/files/team/ejgallego.jpg" alt="Emilio Jesús Gallego Arias" width="220px"/></div>
@@ -193,7 +193,7 @@
     <div class="name"><a href="https://www.lri.fr/~melquion/">Guillaume Melquiond</a></div><div class="nickname">silene</div>
     <div class="position">Inria Researcher in the Toccata Team, Saclay, France</div>
     <div class="role">RM: 8.9, 8.14</div>
-    <div class="components">General Maintenance, <verb>vm_compute</verb>, opam, Reals, Coquelicot, Flocq</div>
+    <div class="components">General Maintenance, <code>vm_compute</code>, opam, Reals, Coquelicot, Flocq</div>
   </div>
   <div class="person">
     <div class="picture"><img src="/files/team/ppedrot.png" alt="Pierre-Marie Pédrot" width="220px"/><br/></div>
@@ -225,7 +225,7 @@
     <div class="name"><a href="https://www.theozimmermann.net/en/">Théo Zimmermann</a></div><div class="nickname">Zimmi48</div>
     <div class="position">Associate Professor at Télécom Paris, Institut Polytechnique de Paris, France</div>
     <div class="role">RM: 8.7, 8.8, 8.12, 8.17, coq-community manager</div>
-    <div class="components">Documentation, Community Management, devtools, <verb>coqbot</verb>, website</div>
+    <div class="components">Documentation, Community Management, devtools, <code>coqbot</code>, website</div>
   </div>
 </div>
 
@@ -314,7 +314,7 @@
     <div class="name"><a href="http://www-sop.inria.fr/members/Benjamin.Gregoire/">Benjamin Grégoire</a></div>
     <div class="nickname">bgregoir</div>
     <div class="position">Inria Researcher in the Stamp Team, Sophia-Antipolis, France</div>
-    <div class="components">Ring, <verb>vm_compute</verb></div>
+    <div class="components">Ring, <code>vm_compute</code></div>
   </div>
   <div class="person">
     <div class="picture"><img src="/files/team/vbgl.jpg" alt="Vincent Laporte" width="160px"/></div>
@@ -391,7 +391,7 @@
     <div class="picture"><img src="/files/team/aspiwack.png" alt="Arnaud Spiwack" width="180px"/></div>
     <div class="name"><a href="http://assert-false.science/arnaud/">Arnaud Spiwack</a></div><div class="nickname">aspiwack</div>
     <div class="position">Senior Architect at Tweag, Paris, France</div>
-    <div class="components">Proof Engine, <verb>vm_compute</verb></div>
+    <div class="components">Proof Engine, <code>vm_compute</code></div>
   </div>
   <div class="person">
     <div class="picture"><img src="/files/team/thery.png" alt="Laurent Théry" width="200px"/></div>

--- a/pages/coq-team.html
+++ b/pages/coq-team.html
@@ -133,7 +133,7 @@
 <div class="coordinator">
   <div class="title">Project Coordinator</div>
   <div class="person">
-    <div class="picture"><img src="/files/team/mattam82.png" alt="Matthieu Sozeau" width="170px"/></div>
+    <div class="picture"><img src="/files/team/mattam82.png" alt="Matthieu Sozeau" width="170"/></div>
     <div class="name"><a href="https://mattam.org">Matthieu Sozeau</a></div><div class="nickname">mattam82</div>
     <div class="position">Inria Researcher in the Gallinette Team, Nantes, France</div>
     <div class="role">Co-RM: 8.2-8.5</div>
@@ -143,7 +143,7 @@
 <div class="team">
   <div class="team-name"><h1>Core Team</h1></div>
   <div class="person">
-    <div class="picture"><img src="/files/team/YvesBertot.png" alt="Yves Bertot" width="200px"/></div>
+    <div class="picture"><img src="/files/team/YvesBertot.png" alt="Yves Bertot" width="200"/></div>
     <div class="name"><a href="http://www-sop.inria.fr/members/Yves.Bertot/research.html">Yves Bertot</a></div><div class="nickname">YvesBertot</div>
     <div class="position">Inria Researcher, Head of the Stamp Team, Sophia-Antipolis, France</div>
     <div class="role">Head of the Coq Consortium</div>
@@ -151,7 +151,7 @@
       Mathematical Components</div>
   </div>
   <div class="person">
-    <div class="picture"><img src="/files/team/maximedenes.jpg" alt="Maxime Dénès" width="200px"/><br/></div>
+    <div class="picture"><img src="/files/team/maximedenes.jpg" alt="Maxime Dénès" width="200"/><br/></div>
     <div class="name"><a href="https://maximedenes.fr">Maxime Dénès</a></div>
     <div class="nickname">maximedenes</div>
     <div class="position">Inria Engineer in the Coq Consortium, attached to the Stamp Team, Sophia-Antipolis, France</div>
@@ -159,14 +159,14 @@
     <div class="components">General Maintenance, CI, <code>native_compute</code>, Kernel, Unification, VSCoq</div>
   </div>  
   <div class="person">
-    <div class="picture"><img src="/files/team/ejgallego.jpg" alt="Emilio Jesús Gallego Arias" width="220px"/></div>
+    <div class="picture"><img src="/files/team/ejgallego.jpg" alt="Emilio Jesús Gallego Arias" width="220"/></div>
     <div class="name"><a href="https://www.irif.fr/~gallego/">Emilio Jesús Gallego Arias</a></div><div class="nickname">ejgallego</div>
     <div class="position">Inria Starting Researcher in the Picube Team, Paris, France</div>
     <div class="role">RM: 8.12</div>
     <div class="components">General Maintenance, Architecture, Frontend, Interfaces, Build System (dune), SerAPI, JSCoq</div>
   </div>
   <div class="person">
-    <div class="picture"><img src="/files/team/SkySkimmer.png" alt="Gaëtan Gilbert" width="200px"/><br/></div>
+    <div class="picture"><img src="/files/team/SkySkimmer.png" alt="Gaëtan Gilbert" width="200"/><br/></div>
     <div class="name"><a href="https://www.ls2n.fr/annuaire/Gaetan%20GILBERT/">Gaëtan Gilbert</a></div>
     <div class="nickname">SkySkimmer</div>
     <div class="position">Inria Engineer in the Coq Consortium, attached to the Gallinette Team, Nantes, France</div>
@@ -174,14 +174,14 @@
     <div class="components">General Maintenance, Theory, CI, Kernel, Universes, SProp, Lean Importer</div>
   </div>
   <div class="person">
-    <div class="picture"><img src="/files/team/JasonGross.jpg" alt="Jason Gross" width="150px"/></div>
+    <div class="picture"><img src="/files/team/JasonGross.jpg" alt="Jason Gross" width="150"/></div>
     <div class="name"><a href="https://people.csail.mit.edu/jgross/">Jason Gross</a></div><div class="nickname">JasonGross</div>
     <div class="position">Postdoctoral researcher at MIRI, USA</div>
     <div class="components">Stress Testing, Bug Reporting, Bug Minimizer, Compatibility Assurance</div>
   </div>
   <div class="person">
     <div class="picture">
-      <img src="/files/team/herbelin.png" alt="Hugo Herbelin" width="170px"/>
+      <img src="/files/team/herbelin.png" alt="Hugo Herbelin" width="170"/>
     </div>
     <div class="name"><a href="http://pauillac.inria.fr/~herbelin/">Hugo Herbelin</a></div><div class="nickname">herbelin</div>
     <div class="position">Inria Researcher in the Picube Team, Paris, France.</div>
@@ -189,14 +189,14 @@
     <div class="components">General Maintenance, Theory, Kernel, Notations, Universes, Elaboration, Unification, Standard Library, Tactics</div>
   </div>
   <div class="person">
-    <div class="picture"><img src="/files/team/silene.jpg" alt="Guillaume Melquiond" width="150px"/></div>
+    <div class="picture"><img src="/files/team/silene.jpg" alt="Guillaume Melquiond" width="150"/></div>
     <div class="name"><a href="https://www.lri.fr/~melquion/">Guillaume Melquiond</a></div><div class="nickname">silene</div>
     <div class="position">Inria Researcher in the Toccata Team, Saclay, France</div>
     <div class="role">RM: 8.9, 8.14</div>
     <div class="components">General Maintenance, <code>vm_compute</code>, opam, Reals, Coquelicot, Flocq</div>
   </div>
   <div class="person">
-    <div class="picture"><img src="/files/team/ppedrot.png" alt="Pierre-Marie Pédrot" width="220px"/><br/></div>
+    <div class="picture"><img src="/files/team/ppedrot.png" alt="Pierre-Marie Pédrot" width="220"/><br/></div>
     <div class="name"><a href="https://www.pédrot.fr">Pierre-Marie Pédrot</a></div>
     <div class="nickname">ppedrot</div>
     <div class="position">Inria Researcher in the Gallinette Team, Nantes, France</div>
@@ -205,7 +205,7 @@
   </div>
   <div class="person">
     <div class="picture">
-      <img src="/files/team/proux.jpg" alt="Pierre Roux" width="200px"/>
+      <img src="/files/team/proux.jpg" alt="Pierre Roux" width="200"/>
     </div>
     <div class="name"><a href="https://www.onera.fr/fr/staff/pierre-roux">Pierre Roux</a></div>
     <div class="nickname">proux01</div>
@@ -213,7 +213,7 @@
     <div class="components">Primitive Types</div>
   </div>
   <div class="person">
-    <div class="picture"><img src="/files/team/gares.jpg" alt="Enrico Tassi" width="230px"/><br/></div>
+    <div class="picture"><img src="/files/team/gares.jpg" alt="Enrico Tassi" width="230"/><br/></div>
     <div class="name"><a href="http://www-sop.inria.fr/members/Enrico.Tassi/">Enrico Tassi</a></div>
     <div class="nickname">gares</div>
     <div class="position">Inria Researcher in the Stamp Team, Sophia-Antipolis, France</div>
@@ -221,7 +221,7 @@
     <div class="components">General Maintenance, STM, SSReflect, opam, VSCoq, Mathematical Components, Coq-Elpi, Hierarchy Builder</div>
   </div>
   <div class="person">
-    <div class="picture"><img src="/files/team/Zimmi48.jpg" alt="Théo Zimmermann" width="200px"/></div>
+    <div class="picture"><img src="/files/team/Zimmi48.jpg" alt="Théo Zimmermann" width="200"/></div>
     <div class="name"><a href="https://www.theozimmermann.net/en/">Théo Zimmermann</a></div><div class="nickname">Zimmi48</div>
     <div class="position">Associate Professor at Télécom Paris, Institut Polytechnique de Paris, France</div>
     <div class="role">RM: 8.7, 8.8, 8.12, 8.17, coq-community manager</div>
@@ -233,27 +233,27 @@
 <div class="team">
   <div class="team-name"><h1>Maintainers</h1></div>
   <div class="person">
-    <div class="picture"><img src="/files/team/fbesson.jpg" alt="Fréderic Besson" width="180px"/><br/></div>
+    <div class="picture"><img src="/files/team/fbesson.jpg" alt="Fréderic Besson" width="180"/><br/></div>
     <div class="name"><a href="http://people.rennes.inria.fr/Frederic.Besson/">Frédéric Besson</a></div>
     <div class="nickname">fbesson</div>
     <div class="position">Inria Researcher in the Celtique Team, Rennes, France</div>
     <div class="components">Decision Procedures</div>
   </div>
    <div class="person">
-    <div class="picture"><img src="/files/team/ana-borges.jpg" alt="Ana de Almeida Borges" width="200px"/></div>
+    <div class="picture"><img src="/files/team/ana-borges.jpg" alt="Ana de Almeida Borges" width="200"/></div>
     <div class="name"><a href="https://aborges.eu/">Ana de Almeida Borges</a></div>
     <div class="nickname">ana-borges</div>
     <div class="position">PhD student at the University of Barcelona, Spain</div>
     <div class="components">Signed primitive integers</div>
   </div>
   <div class="person">
-    <div class="picture"><img src="/files/team/alizter.jpg" alt="Ali Caglayan" width="180px"/></div>
+    <div class="picture"><img src="/files/team/alizter.jpg" alt="Ali Caglayan" width="180"/></div>
     <div class="name"><a href="http://github.com/alizter">Ali Caglayan</a></div><div class="nickname">alizter</div>
     <div class="position">Master student at the University of Gothenburg, Sweden</div>
     <div class="components">CoqIDE, CI, Numbers</div>
   </div>
   <div class="person">
-    <div class="picture"><img src="/files/team/tej-chajed.jpg" alt="Tej Chajed" width="200px"/></div>
+    <div class="picture"><img src="/files/team/tej-chajed.jpg" alt="Tej Chajed" width="200"/></div>
     <div class="name"><a href="https://www.chajed.io/">Tej Chajed</a></div>
     <div class="nickname">tchajed</div>
     <div class="position">Postdoctoral researcher at VMware Research</div>
@@ -261,7 +261,7 @@
   </div>
   <div class="person">
     <div class="picture">
-      <img src="/files/team/clarus.jpg" alt="Guillaume Claret" width="200px"/>
+      <img src="/files/team/clarus.jpg" alt="Guillaume Claret" width="200"/>
     </div>
     <div class="name"><a href="http://guillaume.claret.me/">Guillaume Claret</a></div><div class="nickname">clarus</div>
     <div class="position">Coq Engineer at Formal Land, Paris, France</div>
@@ -269,14 +269,14 @@
   </div>
   <div class="person">
     <div class="picture">
-      <img src="/files/team/cyril-cohen.png" alt="Cyril Cohen" width="200px"/></div>
+      <img src="/files/team/cyril-cohen.png" alt="Cyril Cohen" width="200"/></div>
     <div class="name"><a href="http://cyrilcohen.fr">Cyril Cohen</a></div><div class="nickname">CohenCyril</div>
     <div class="position">Inria Researcher in the Stamp Team, Sophia-Antipolis, France</div>
     <div class="components">Opam, Nix, Mathematical Components, Hierarchy Builder</div>
   </div>
 
   <div class="person">
-    <div class="picture"><img src="/files/team/PierreCorbineau.jpg" alt="Pierre Corbineau" width="170px"/></div>
+    <div class="picture"><img src="/files/team/PierreCorbineau.jpg" alt="Pierre Corbineau" width="170"/></div>
     <div class="name"><a href="https://www-verimag.imag.fr/~corbinea/">
       Pierre Corbineau</a></div><div class="nickname">PierreCorbineau</div>
     <div class="position">Associate Professor at VERIMAG, Grenoble, France</div>
@@ -284,19 +284,19 @@
   </div>
   
   <div class="person">
-    <div class="picture"><img src="/files/team/matafou.png" alt="Pierre Courtieu" width="170px"/></div>
+    <div class="picture"><img src="/files/team/matafou.png" alt="Pierre Courtieu" width="170"/></div>
     <div class="name"><a href="http://cedric.cnam.fr/~courtiep/">Pierre Courtieu</a></div><div class="nickname">Matafou</div>
     <div class="position">Associate Professor at CNAM, Paris, France</div>
     <div class="components">Function, Proof-General</div>
   </div>
   <div class="person">
-    <div class="picture"><img src="/files/team/nopic.png" alt="Jim Fehrle" width="200px"/></div>
+    <div class="picture"><img src="/files/team/nopic.png" alt="Jim Fehrle" width="200"/></div>
     <div class="name">Jim Fehrle</div><div class="nickname">jfehrle</div>
     <div class="position">Software Engineer in Menlo Park, CA, USA</div>
     <div class="components">Documentation, Proof diffs, Ltac debugger</div>
   </div>
   <div class="person">
-    <div class="picture"><img src="/files/team/nopic.png" alt="Julien Forest" width="200px"/></div>
+    <div class="picture"><img src="/files/team/nopic.png" alt="Julien Forest" width="200"/></div>
     <div class="name"><a href="http://web4.ensiie.fr/~forest/">Julien Forest</a></div>
     <div class="nickname">forestjulien</div>
     <div class="position">Associate Professor at ENSIEE/CNAM, Evry/Paris, France</div>
@@ -304,27 +304,27 @@
   </div>
   <div class="person">
     <div class="picture">
-      <img src="/files/team/ggonthier.jpg" alt="Georges Gonthier" width="200px"/></div>
+      <img src="/files/team/ggonthier.jpg" alt="Georges Gonthier" width="200"/></div>
     <div class="name">Georges Gonthier</div><div class="nickname">ggonthier</div>
     <div class="position">Inria Advanced Researcher in Saclay, France</div>
     <div class="components">SSReflect, Mathematical Components, Notations</div>
   </div>
   <div class="person">
-    <div class="picture"><img src="/files/team/bgregoir.jpg" alt="Benjamin Grégoire" width="170px"/></div>
+    <div class="picture"><img src="/files/team/bgregoir.jpg" alt="Benjamin Grégoire" width="170"/></div>
     <div class="name"><a href="http://www-sop.inria.fr/members/Benjamin.Gregoire/">Benjamin Grégoire</a></div>
     <div class="nickname">bgregoir</div>
     <div class="position">Inria Researcher in the Stamp Team, Sophia-Antipolis, France</div>
     <div class="components">Ring, <code>vm_compute</code></div>
   </div>
   <div class="person">
-    <div class="picture"><img src="/files/team/vbgl.jpg" alt="Vincent Laporte" width="160px"/></div>
+    <div class="picture"><img src="/files/team/vbgl.jpg" alt="Vincent Laporte" width="160"/></div>
     <div class="name"><a href="https://members.loria.fr/VLaporte/">Vincent Laporte</a></div><div class="nickname">vbgl</div>
     <div class="position">Inria Researcher in the Pesto Team, Nancy, France</div>
     <div class="role">RM: 8.10</div>
     <div class="components">Nix, micromega</div>
   </div>
   <div class="person">
-    <div class="picture"><img src="/files/team/olivier-laurent.jpg" alt="Olivier Laurent" width="200px"/></div>
+    <div class="picture"><img src="/files/team/olivier-laurent.jpg" alt="Olivier Laurent" width="200"/></div>
     <div class="name"><a href="https://perso.ens-lyon.fr/olivier.laurent/">Olivier Laurent</a></div>
     <div class="nickname">olaure01</div>
     <div class="position">CNRS Researcher in the Plume Team, Lyon, France</div>
@@ -332,14 +332,14 @@
   </div>
   <div class="person">
     <div class="picture">
-      <img src="/files/team/assia_mahboubi.jpg" alt="Assia Mahboubi" width="200px"/></div>
+      <img src="/files/team/assia_mahboubi.jpg" alt="Assia Mahboubi" width="200"/></div>
     <div class="name"><a href="http://people.rennes.inria.fr/Assia.Mahboubi/">Assia Mahboubi</a></div><div class="nickname">amahboubi</div>
     <div class="position">Inria Researcher in the Gallinette Team, Nantes, France</div>
     <div class="role"><a href="https://cordis.europa.eu/project/id/101001995">ERC FRESCO PI</a></div>
     <div class="components">Ring, SSReflect, Mathematical Components</div>
   </div>
   <div class="person">
-    <div class="picture"><img src="/files/team/kenji-maillard.jpg" alt="Kenji Maillard" width="200px"/></div>
+    <div class="picture"><img src="/files/team/kenji-maillard.jpg" alt="Kenji Maillard" width="200"/></div>
     <div class="name"><a href="https://kenji.maillard.blue/">Kenji Maillard</a></div>
     <div class="nickname">kyod</div>
     <div class="position">Inria Researcher in the Gallinette Team, Nantes, France</div>
@@ -347,7 +347,7 @@
   </div>
   <div class="person">
     <div class="picture">
-      <img src="/files/team/erikmd.png" alt="Érik Martin-Dorel" width="170px"/>
+      <img src="/files/team/erikmd.png" alt="Érik Martin-Dorel" width="170"/>
     </div>
     <div class="name"><a href="https://www.irit.fr/~Erik.Martin-Dorel/">Érik Martin-Dorel</a></div><div class="nickname">erikmd</div>
     <div class="position">Associate Professor at IRIT, Toulouse University, France</div>
@@ -355,7 +355,7 @@
   </div>
   <div class="person">
     <div class="picture">
-      <img src="/files/team/palmskog.jpg" alt="Karl Palmskog" width="190px"/>
+      <img src="/files/team/palmskog.jpg" alt="Karl Palmskog" width="190"/>
     </div>
     <div class="name"><a href="https://setoid.com/">Karl Palmskog</a></div><div class="nickname">palmskog</div>
     <div class="position">Researcher at the KTH Royal Institute of Technology, Stockholm, Sweden</div>
@@ -364,50 +364,50 @@
   </div>
   <div class="person">
     <div class="picture">
-      <img src="/files/team/cpitclaudel.jpg" alt="Clément Pit-Claudel" width="170px"/>
+      <img src="/files/team/cpitclaudel.jpg" alt="Clément Pit-Claudel" width="170"/>
     </div>
     <div class="name"><a href="http://pit-claudel.fr/clement/">Clément Pit-Claudel</a></div><div class="nickname">cpitclaudel</div>
     <div class="position">Assistant Professor at EPFL, Lausanne, Switzerland</div>
     <div class="components">Documentation, Alectryon, SerAPI, Proof-General, Company-Coq</div>
   </div>
   <div class="person">
-    <div class="picture"><img src="/files/team/pi8027.jpg" alt="Kazuhiko Sakaguchi" width="200px"/></div>
+    <div class="picture"><img src="/files/team/pi8027.jpg" alt="Kazuhiko Sakaguchi" width="200"/></div>
     <div class="name">Kazuhiko Sakaguchi</div><div class="nickname">pi8027</div>
     <div class="position">Inria Research Engineer in the Gallinette Team, Nantes, France</div>
     <div class="components">Coercions, Extraction, Mathematical Components, Hierarchy Builder</div>
   </div>   
   <div class="person">
-    <div class="picture"><img src="/files/team/VincentSe.jpg" alt="Vincent Semeria" width="200px"/></div>
+    <div class="picture"><img src="/files/team/VincentSe.jpg" alt="Vincent Semeria" width="200"/></div>
     <div class="name">Vincent Semeria</div><div class="nickname">VincentSe</div>
     <div class="position">Expert Software Developer at Finastra, Paris, France</div>
     <div class="components">Reals</div>
   </div>
   <div class="person">
-    <div class="picture"><img src="/files/team/MSoegtropIMC.jpg" alt="Michael Soegtrop" width="200px"/></div>
+    <div class="picture"><img src="/files/team/MSoegtropIMC.jpg" alt="Michael Soegtrop" width="200"/></div>
     <div class="name">Michael Soegtrop</div><div class="nickname">MSoegtropIMC</div>
     <div class="components">Coq Platform, Standard Library</div>
   </div>
   <div class="person">
-    <div class="picture"><img src="/files/team/aspiwack.png" alt="Arnaud Spiwack" width="180px"/></div>
+    <div class="picture"><img src="/files/team/aspiwack.png" alt="Arnaud Spiwack" width="180"/></div>
     <div class="name"><a href="http://assert-false.science/arnaud/">Arnaud Spiwack</a></div><div class="nickname">aspiwack</div>
     <div class="position">Senior Architect at Tweag, Paris, France</div>
     <div class="components">Proof Engine, <code>vm_compute</code></div>
   </div>
   <div class="person">
-    <div class="picture"><img src="/files/team/thery.png" alt="Laurent Théry" width="200px"/></div>
+    <div class="picture"><img src="/files/team/thery.png" alt="Laurent Théry" width="200"/></div>
     <div class="name">Laurent Théry</div><div class="nickname">thery</div>
     <div class="position">Inria Researcher in the Stamp Team, Sophia-Antipolis, France</div>
     <div class="components">Standard Library, Mathematical Components</div>
   </div>
   <div class="person">
-    <div class="picture"><img src="/files/team/anton-trunov.jpg" alt="Anton Trunov" width="200px"/></div>
+    <div class="picture"><img src="/files/team/anton-trunov.jpg" alt="Anton Trunov" width="200"/></div>
     <div class="name">Anton Trunov</div>
     <div class="nickname">anton-trunov</div>
     <div class="position">Research Engineer at Zilliqa Research, Saint Petersburg, Russia</div>
     <div class="components">Standard Library, Build Tools</div>
   </div>
   <div class="person">
-    <div class="picture"><img src="/files/team/Lysxia.jpg" alt="Li-Yao Xia" width="200px"/></div>
+    <div class="picture"><img src="/files/team/Lysxia.jpg" alt="Li-Yao Xia" width="200"/></div>
     <div class="name"><a href="https://poisson.chat/">Li-Yao Xia</a></div><div class="nickname">Lysxia</div>
     <div class="position">Postdoctoral researcher at the University of Edinburgh, Scotland, UK</div>
     <div class="components">coqdoc</div>
@@ -419,7 +419,7 @@
   <div class="team-name"><h1>Members at Large</h1></div>
   <div class="person">
     <div class="picture">
-        <img src="/files/team/nicolas-tabareau.jpg" alt="Nicolas Tabareau" width="140px"/></div>
+        <img src="/files/team/nicolas-tabareau.jpg" alt="Nicolas Tabareau" width="140"/></div>
     <div class="name"><a href="https://tabareau.fr/">Nicolas Tabareau</a></div><div class="nickname">tabareau</div>
     <div class="position">Inria Researcher, Head of the Gallinette Team, Nantes, France</div>
     <div class="role"><a href="http://coqhott.gforge.inria.fr/">ERC Coq-HoTT PI</a>, Inria-Nomadic Labs CoqExtra</div>
@@ -430,7 +430,7 @@
   <div class="team-name"><h1>Past Core Team Members</h1></div>
   <div class="person">
     <div class="picture">
-        <img src="/files/team/coquand.jpg" alt="Thierry Coquand" width="200px"/></div>
+        <img src="/files/team/coquand.jpg" alt="Thierry Coquand" width="200"/></div>
     <div class="name"><a href="http://www.cse.chalmers.se/~coquand/">Thierry Coquand</a></div>
     <div class="position">Professor at the University of Gothenburg, Sweden</div>
     <div class="role">Creator (1984), V1-V5</div>
@@ -438,7 +438,7 @@
   </div>
   <div class="person">
     <div class="picture">
-        <img src="/files/team/huet.jpg" alt="Gérard Huet" width="160px"/></div>
+        <img src="/files/team/huet.jpg" alt="Gérard Huet" width="160"/></div>
     <div class="name"><a href="http://pauillac.inria.fr/~huet/">Gérard Huet</a></div>
     <div class="position">Inria Emeritus Researcher, Paris, France</div>
     <div class="role">Creator and Head of the Project (1984-1995), V1-V5</div>
@@ -446,7 +446,7 @@
   </div>
   <div class="person">
     <div class="picture">
-        <img src="/files/team/dowek.jpg" alt="Gilles Dowek" width="200px"/></div>
+        <img src="/files/team/dowek.jpg" alt="Gilles Dowek" width="200"/></div>
     <div class="name"><a href="lsv.fr/~dowek/">Gilles Dowek</a></div>
     <div class="position">Inria Researcher, Head of the Deducteam Team, Gif-sur-Yvette, France</div>
     <div class="role">V4.3-V4.11</div>
@@ -454,7 +454,7 @@
   </div>
   <div class="person">
     <div class="picture">
-        <img src="/files/team/paulin-elba.jpg" alt="Christine Paulin-Mohring" width="200px"/></div>
+        <img src="/files/team/paulin-elba.jpg" alt="Christine Paulin-Mohring" width="200"/></div>
     <div class="name"><a href="https://www.lri.fr/~paulin/">Christine Paulin-Mohring</a></div>
     <div class="position">Professor at the University of Paris-Saclay, France</div>
     <div class="role">V4.4-V8, Head of the Project (1995-2006)</div>
@@ -462,7 +462,7 @@
   </div>
   <div class="person">
     <div class="picture">
-        <img src="/files/team/nopic.png" alt="Chetan R. Murthy" width="200px"/></div>
+        <img src="/files/team/nopic.png" alt="Chetan R. Murthy" width="200"/></div>
     <div class="name"><a href="https://www.lri.fr/~paulin/">Chetan R. Murthy</a></div>
     <div class="position">Independent Computer Scientist, San Francisco, CA, USA</div>
     <div class="role">V5 Architect (1993)</div>
@@ -470,7 +470,7 @@
   </div>
   <div class="person">
     <div class="picture">
-        <img src="/files/team/Eduardo-Gimenez.jpg" alt="Eduardo Giménez" width="200px"/></div>
+        <img src="/files/team/Eduardo-Gimenez.jpg" alt="Eduardo Giménez" width="200"/></div>
     <div class="name"><a href="https://www.researchgate.net/profile/Eduardo-Gimenez-2">Eduardo Giménez</a></div>
     <div class="position">Operating Officer at ICT4V, Montevideo, Uruguay</div>
     <div class="role">V6-7</div>
@@ -478,7 +478,7 @@
   </div>
   <div class="person">
     <div class="picture">
-        <img src="/files/team/backtracking.jpg" alt="Jean-Christophe Filliâtre" width="200px"/></div>
+        <img src="/files/team/backtracking.jpg" alt="Jean-Christophe Filliâtre" width="200"/></div>
     <div class="name"><a href="https://www.lri.fr/~filliatr/">Jean-Christophe Filliâtre</a></div>
     <div class="nickname">backtracking</div>
     <div class="position">Senior CNRS Researcher, Saclay, France</div>
@@ -487,7 +487,7 @@
   </div>
   <div class="person">
     <div class="picture">
-        <img src="/files/team/barras.jpg" alt="Bruno Barras" width="200px"/></div>
+        <img src="/files/team/barras.jpg" alt="Bruno Barras" width="200"/></div>
     <div class="name"><a href="http://www.lsv.fr/~barras/">Bruno Barras</a></div>
     <div class="nickname">barras</div>
     <div class="position">Inria Researcher in the Deducteam Team, Gif-sur-Yvette, France</div>
@@ -498,14 +498,14 @@
   </div>
   <div class="person">
     <div class="picture">
-        <img src="/files/team/werner.png" alt="Benjamin Werner" width="180px"/></div>
+        <img src="/files/team/werner.png" alt="Benjamin Werner" width="180"/></div>
     <div class="name"><a href="/">Benjamin Werner</a></div>
     <div class="position">Inria Researcher at École Polytechnique, Palaiseau, France</div>
     <div class="components">Theory, Inductive Types, Proof Irrelevance</div>
   </div>
   <div class="person">
     <div class="picture">
-        <img src="/files/team/delahaye.png" alt="David Delahaye" width="140px"/></div>
+        <img src="/files/team/delahaye.png" alt="David Delahaye" width="140"/></div>
     <div class="name"><a href="http://www.lirmm.fr/~delahaye/">David Delahaye</a></div>
     <div class="nickname">delahayd</div>
     <div class="position">Professor at the University of Montpellier, France</div>
@@ -514,7 +514,7 @@
   </div>
   <div class="person">
     <div class="picture">
-        <img src="/files/team/Letouzey.png" alt="Pierre Letouzey" width="150px"/></div>
+        <img src="/files/team/Letouzey.png" alt="Pierre Letouzey" width="150"/></div>
     <div class="name"><a href="https://www.irif.fr/en/users/letouzey/index/">Pierre Letouzey</a></div><div class="nickname">letouzey</div>
     <div class="position">Associate Professor at IRIF, Paris, France</div>
     <div class="role">V7-V8.9, Co-RM: V8.0-V8.5</div>
@@ -522,7 +522,7 @@
   </div>
   <div class="person">
     <div class="picture">
-        <img src="/files/team/monate.jpg" alt="Benjamin Monate" width="180px"/></div>
+        <img src="/files/team/monate.jpg" alt="Benjamin Monate" width="180"/></div>
     <div class="name"><a href="">Benjamin Monate</a></div><div class="nickname">monate</div>
     <div class="position">Founder & CTO at TrustInSoft, Paris, France</div>
     <div class="role">V8</div>

--- a/pages/coq-team.html
+++ b/pages/coq-team.html
@@ -204,6 +204,15 @@
     <div class="components">General Maintenance, Theory, Performance, Kernel, Elaboration, Universes, Ltac 1/2, Forcing</div>
   </div>
   <div class="person">
+    <div class="picture">
+      <img src="/files/team/proux.jpg" alt="Pierre Roux" width="200px"/>
+    </div>
+    <div class="name"><a href="https://www.onera.fr/fr/staff/pierre-roux">Pierre Roux</a></div>
+    <div class="nickname">proux01</div>
+    <div class="position">Researcher at Onera, Toulouse, France</div>
+    <div class="components">Primitive Types</div>
+  </div>
+  <div class="person">
     <div class="picture"><img src="/files/team/gares.jpg" alt="Enrico Tassi" width="230px"/><br/></div>
     <div class="name"><a href="http://www-sop.inria.fr/members/Enrico.Tassi/">Enrico Tassi</a></div>
     <div class="nickname">gares</div>
@@ -360,14 +369,6 @@
     <div class="name"><a href="http://pit-claudel.fr/clement/">Clément Pit-Claudel</a></div><div class="nickname">cpitclaudel</div>
     <div class="position">Assistant Professor at EPFL, Lausanne, Switzerland</div>
     <div class="components">Documentation, Alectryon, SerAPI, Proof-General, Company-Coq</div>
-  </div>
-  <div class="person">
-    <div class="picture">
-      <img src="/files/team/proux.jpg" alt="Pierre Roux" width="200px"/>
-    </div>
-    <div class="name"><a href="https://www.onera.fr/fr/staff/pierre-roux">Pierre Roux</a></div><div class="nickname">proux01</div>
-    <div class="position">Researcher at Onera, Toulouse, France</div>
-    <div class="components">Primitive Types</div>
   </div>
   <div class="person">
     <div class="picture"><img src="/files/team/pi8027.jpg" alt="Kazuhiko Sakaguchi" width="200px"/></div>

--- a/pages/coq-team.html
+++ b/pages/coq-team.html
@@ -70,7 +70,7 @@
 .nickname {
     /* display: inline; */
     text-align: center;
-    font-style: bold;
+    font-weight: bold;
     font-family: 'Courier New', Courier, monospace;;
     font-size: 10pt;
     margin-top: 3px;


### PR DESCRIPTION
One bug was left unfixed. The explicit doctype `<!DOCTYPE html>` at the top of the page causes browsers to choke on the implicit doctype coming from `incl/header.html`.