### PR TITLE
Set current version to 8.17.0.

### DIFF
--- a/incl/macros.html
+++ b/incl/macros.html
@@ -1,3 +1,3 @@
-<#def CURRENTVERSION>8.16.1</#def>
+<#def CURRENTVERSION>8.17.0</#def>
 <#def CURRENTVERSIONTAG>V<#CURRENTVERSION></#def>
 <#def CURRENTCREDITSURL>https://github.com/coq/coq/blob/<#CURRENTVERSIONTAG>/CREDITS</#def>


### PR DESCRIPTION
Since this is only used in the opam instructions, this should be merged after the opam packages are available (cc @palmskog).