### PR TITLE
update CURRENTVERSION to 8.17.1

### DIFF
--- a/incl/macros.html
+++ b/incl/macros.html
@@ -1,3 +1,3 @@
-<#def CURRENTVERSION>8.17.0</#def>
+<#def CURRENTVERSION>8.17.1</#def>
 <#def CURRENTVERSIONTAG>V<#CURRENTVERSION></#def>
 <#def CURRENTCREDITSURL>https://github.com/coq/coq/blob/<#CURRENTVERSIONTAG>/CREDITS</#def>


### PR DESCRIPTION
To be merged when `coqide.8.17.1` appears on opam.

cc: @Zimmi48 