### PR TITLE
Advertise Code of Conduct on website.

### DIFF
--- a/pages/community.html
+++ b/pages/community.html
@@ -5,6 +5,11 @@
 <div class="frameworklabel">Communication channels</div>
 <div class="frameworkcontent">
 
+<p>We have a <a href="https://github.com/coq/coq/blob/master/CODE_OF_CONDUCT.md">
+code of conduct</a> that applies to all spaces (online forums as well as physical
+events) managed by the Coq team. Make sure you read it and abide by it. Note that
+it contains a section specifically on how to ask questions on Coq forums.</p>
+
 <p>
 There are several channels to reach the user community and the
 development team:
@@ -55,10 +60,10 @@ from many of the above channels.
 
 <div class="frameworklinks">
 <ul>
+<li><a class="extlink" href="https://github.com/coq/coq/blob/master/CODE_OF_CONDUCT.md">Code of Conduct</a></li>
 <li><a class="extlink" href="https://proofassistants.stackexchange.com">Proof Assistants SE</a></li>
 <li><a class="extlink" href="https://coq.discourse.group">Discourse forum</a></li>
 <li><a class="extlink" href="https://coq.zulipchat.com">Zulip chat</a></li>
-<li><a class="extlink" href="https://twitter.com/CoqLang">Twitter account</a></li>
 </ul>
 </div>
 </div>

--- a/pages/index.html
+++ b/pages/index.html
@@ -71,6 +71,9 @@ curated list of projects and resources). We have a multi-lingual
 <a href="https://coq.gitlab.io/zulip-archive/">openly accessible archive</a>.
 </p>
 
+<p>Note our <a href="https://github.com/coq/coq/blob/master/CODE_OF_CONDUCT.md">code of conduct</a>
+that applies to all spaces managed by the Coq team, including online forums and physical events.</p>
+
 </div>
 
 <div class="frameworklinks">


### PR DESCRIPTION
The Coq Community Survey 2022 reveal that a large part of the community (especially newcomers) was not aware of the code of conduct, and an even larger part had not read it. This is an attempt at improving the situation by advertising the Code of Conduct more broadly, through the Coq website, since it applies beyond the boundaries of the Coq repositories. This also follows the recent addition of a section specifically dedicated to asking questions on Coq forums in the code of conduct.

cc @coq/code-of-conduct-team